### PR TITLE
Fix mischaracterization of phase 5-9 detour as deliberate

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -570,7 +570,7 @@ Adding SWAP/OVER/ROT transforms the ISA from "theoretically Turing-complete but 
 
 1. **Attention is lookup; feed-forward is routing/arithmetic.** The 2D parabolic attention primitives are elegant, compose cleanly, and are reliably learnable. The hard part is the conditional logic in FF layers — and for arithmetic, it must be compiled, not trained.
 
-2. **The training detour (Phases 5–9) was essential.** It precisely characterized what gradient descent can and cannot learn about execution. Retrieval: learnable. Routing: learnable. Doubling: learnable with help. True addition: not learnable in multi-task context. This is a fundamental finding about transformer capabilities.
+2. **The training detour (Phases 5–9) was accidental but informative.** It was not a planned departure from Percepta's compile approach — it was drift across sessions caused by not anchoring to their specific claims. But it did characterize what gradient descent can and cannot learn about execution. Retrieval: learnable. Routing: learnable. Doubling: learnable with help. True addition: not learnable in multi-task context.
 
 3. **Compile, don't train.** Percepta's core insight is correct. When arithmetic and routing logic are compiled directly into weight matrices, the transformer executes correctly — including operations that training alone provably cannot learn.
 

--- a/RD-PLAN.md
+++ b/RD-PLAN.md
@@ -54,7 +54,7 @@
 
 ## Phases 5–9: The Training Detour ✅
 
-Phases 5–9 explored whether gradient descent could learn execution from data — a deliberate departure from Percepta's compile approach. While this path didn't achieve perfect execution, it produced essential findings about what transformers can and cannot learn.
+Phases 5–9 explored whether gradient descent could learn execution from data. This was not a deliberate departure from Percepta's compile approach — it was accidental drift across sessions, caused by not anchoring our plan to an extractive summary of Percepta's specific claims. While this path didn't achieve perfect execution, it produced useful findings about what transformers can and cannot learn.
 
 ### Phase 5: Trained Micro-Executor ✅
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ They released no code or weights. This repo independently tests whether the core
 
 ### Detour: Can Gradient Descent Learn Execution? (Phases 5–9)
 
-Phases 5–9 explored whether a small transformer could *learn* to execute programs from training data alone. This was a deliberate departure from Percepta's compile approach. The journey was instructive — it precisely characterized *why* compilation is necessary.
+Phases 5–9 explored whether a small transformer could *learn* to execute programs from training data alone. This was not a deliberate departure from Percepta's compile approach — it was accidental drift across sessions. Without an extractive summary of Percepta's specific claims pinned to our plan, "let's try training" felt like a natural next step even though the blog post's entire thesis is that compilation, not training, is the answer. The journey was nonetheless instructive — it precisely characterized *why* compilation is necessary.
 
 | Phase | Description | Status | Key Finding |
 |-------|------------|--------|-------------|


### PR DESCRIPTION
The training detour was not a planned departure from Percepta's compile
approach — it was accidental drift across sessions caused by not anchoring
to an extractive summary of Percepta's specific claims. The writeup.md
already told this story honestly, but README.md, RD-PLAN.md, and
FINDINGS.md all claimed or implied it was intentional. Fixed all three.

https://claude.ai/code/session_01TBi95QxFHK7gasBnZAh5op