### PR TITLE
Restructure: extract consolidated modules from phase files

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -1,0 +1,675 @@
+"""Flattened executor classes for the compiled transformer stack machine.
+
+Consolidated from phase11 → phase12 → phase13 → phase14. No inheritance chain.
+Contains:
+  - NumPyExecutor: full 42-opcode numpy executor (flattened from Phase14Executor)
+  - CompiledModel: PyTorch nn.Module with compiled weights (flattened from Phase14Model)
+  - TorchExecutor: executes programs via CompiledModel (flattened from Phase14PyTorchExecutor)
+"""
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from isa import (
+    Instruction, Trace, TraceStep,
+    CompiledAttentionHead,
+    embed_program_token, embed_stack_entry, embed_state,
+    D_MODEL, DTYPE, EPS, N_OPCODES,
+    DIM_IS_PROG, DIM_IS_STACK, DIM_IS_STATE,
+    DIM_PROG_KEY_0, DIM_PROG_KEY_1,
+    DIM_STACK_KEY_0, DIM_STACK_KEY_1,
+    DIM_OPCODE, DIM_VALUE, DIM_IP, DIM_SP, DIM_ONE,
+    OP_PUSH, OP_POP, OP_ADD, OP_DUP, OP_HALT,
+    OP_SUB, OP_JZ, OP_JNZ, OP_NOP,
+    OP_SWAP, OP_OVER, OP_ROT,
+    OP_MUL, OP_DIV_S, OP_DIV_U, OP_REM_S, OP_REM_U,
+    OP_EQZ, OP_EQ, OP_NE,
+    OP_LT_S, OP_LT_U, OP_GT_S, OP_GT_U,
+    OP_LE_S, OP_LE_U, OP_GE_S, OP_GE_U,
+    OP_AND, OP_OR, OP_XOR,
+    OP_SHL, OP_SHR_S, OP_SHR_U, OP_ROTL, OP_ROTR,
+    OP_CLZ, OP_CTZ, OP_POPCNT, OP_ABS, OP_NEG, OP_SELECT,
+    OP_TRAP,
+    OPCODE_DIM_MAP, OPCODE_IDX, NONLINEAR_OPS,
+    _trunc_div, _trunc_rem, _to_i32, MASK32,
+    _shr_u, _shr_s, _rotl32, _rotr32,
+    _clz32, _ctz32, _popcnt32,
+)
+
+
+# ─── NumPy Executor ───────────────────────────────────────────────
+
+class NumPyExecutor:
+    """Compiled numpy executor with full 42-opcode ISA.
+
+    Flattened from Phase14Executor <- Phase13Executor <- ExtendedExecutor <- CompiledExecutorNumpy.
+    """
+
+    def execute(self, prog, max_steps=5000):
+        trace = Trace(program=prog)
+
+        stack_keys = []
+        stack_vals = []
+        write_count = 0
+        eps = 1e-10
+
+        ip = 0
+        sp = 0
+
+        def stack_write(addr, val):
+            nonlocal write_count
+            stack_keys.append((2.0*addr, -float(addr*addr) + eps*write_count))
+            stack_vals.append(val)
+            write_count += 1
+
+        def stack_read(addr):
+            if not stack_keys:
+                return 0
+            keys = np.array(stack_keys)
+            q = np.array([addr, 1.0])
+            scores = keys @ q
+            best = np.argmax(scores)
+            stored_addr = round(keys[best, 0] / 2.0)
+            return stack_vals[best] if stored_addr == addr else 0
+
+        for step in range(max_steps):
+            if ip >= len(prog):
+                break
+
+            op = prog[ip].op
+            arg = prog[ip].arg
+            next_ip = ip + 1
+            top = 0
+
+            # ── Phase 4 base ops ──
+            if op == OP_PUSH:
+                sp += 1
+                stack_write(sp, arg)
+                top = arg
+            elif op == OP_POP:
+                sp -= 1
+                top = stack_read(sp) if sp > 0 else 0
+            elif op == OP_ADD:
+                val_a = stack_read(sp)
+                val_b = stack_read(sp - 1)
+                result = val_a + val_b
+                sp -= 1
+                stack_write(sp, result)
+                top = result
+            elif op == OP_SUB:
+                val_a = stack_read(sp)
+                val_b = stack_read(sp - 1)
+                result = val_b - val_a
+                sp -= 1
+                stack_write(sp, result)
+                top = result
+            elif op == OP_DUP:
+                val = stack_read(sp)
+                sp += 1
+                stack_write(sp, val)
+                top = val
+
+            # ── Phase 13 stack manipulation ──
+            elif op == OP_SWAP:
+                val_a = stack_read(sp)
+                val_b = stack_read(sp - 1)
+                stack_write(sp, val_b)
+                stack_write(sp - 1, val_a)
+                top = val_b
+            elif op == OP_OVER:
+                val_b = stack_read(sp - 1)
+                sp += 1
+                stack_write(sp, val_b)
+                top = val_b
+            elif op == OP_ROT:
+                val_top    = stack_read(sp)
+                val_second = stack_read(sp - 1)
+                val_third  = stack_read(sp - 2)
+                stack_write(sp, val_third)
+                stack_write(sp - 1, val_top)
+                stack_write(sp - 2, val_second)
+                top = val_third
+
+            # ── Phase 14 arithmetic ──
+            elif op == OP_MUL:
+                val_a = stack_read(sp)
+                val_b = stack_read(sp - 1)
+                result = val_a * val_b
+                sp -= 1
+                stack_write(sp, result)
+                top = result
+            elif op in (OP_DIV_S, OP_DIV_U):
+                val_a = stack_read(sp)
+                if val_a == 0:
+                    trace.steps.append(TraceStep(OP_TRAP, 0, sp, 0))
+                    break
+                val_b = stack_read(sp - 1)
+                result = _trunc_div(val_b, val_a)
+                sp -= 1
+                stack_write(sp, result)
+                top = result
+            elif op in (OP_REM_S, OP_REM_U):
+                val_a = stack_read(sp)
+                if val_a == 0:
+                    trace.steps.append(TraceStep(OP_TRAP, 0, sp, 0))
+                    break
+                val_b = stack_read(sp - 1)
+                result = _trunc_rem(val_b, val_a)
+                sp -= 1
+                stack_write(sp, result)
+                top = result
+
+            # ── Phase 14 Chunk 2: comparison ops ──
+            elif op == OP_EQZ:
+                val_a = stack_read(sp)
+                result = 1 if val_a == 0 else 0
+                stack_write(sp, result)
+                top = result
+            elif op in (OP_EQ, OP_NE, OP_LT_S, OP_LT_U, OP_GT_S, OP_GT_U,
+                        OP_LE_S, OP_LE_U, OP_GE_S, OP_GE_U):
+                val_a = stack_read(sp)
+                val_b = stack_read(sp - 1)
+                if op in (OP_EQ,):
+                    result = 1 if val_a == val_b else 0
+                elif op in (OP_NE,):
+                    result = 1 if val_a != val_b else 0
+                elif op in (OP_LT_S, OP_LT_U):
+                    result = 1 if val_b < val_a else 0
+                elif op in (OP_GT_S, OP_GT_U):
+                    result = 1 if val_b > val_a else 0
+                elif op in (OP_LE_S, OP_LE_U):
+                    result = 1 if val_b <= val_a else 0
+                elif op in (OP_GE_S, OP_GE_U):
+                    result = 1 if val_b >= val_a else 0
+                sp -= 1
+                stack_write(sp, result)
+                top = result
+
+            # ── Phase 14 Chunk 3: bitwise ops ──
+            elif op == OP_AND:
+                val_a = stack_read(sp)
+                val_b = stack_read(sp - 1)
+                result = _to_i32(val_a) & _to_i32(val_b)
+                sp -= 1
+                stack_write(sp, result)
+                top = result
+            elif op == OP_OR:
+                val_a = stack_read(sp)
+                val_b = stack_read(sp - 1)
+                result = _to_i32(val_a) | _to_i32(val_b)
+                sp -= 1
+                stack_write(sp, result)
+                top = result
+            elif op == OP_XOR:
+                val_a = stack_read(sp)
+                val_b = stack_read(sp - 1)
+                result = _to_i32(val_a) ^ _to_i32(val_b)
+                sp -= 1
+                stack_write(sp, result)
+                top = result
+            elif op == OP_SHL:
+                val_a = stack_read(sp)
+                val_b = stack_read(sp - 1)
+                result = (_to_i32(val_b) << (int(val_a) & 31)) & MASK32
+                sp -= 1
+                stack_write(sp, result)
+                top = result
+            elif op == OP_SHR_S:
+                val_a = stack_read(sp)
+                val_b = stack_read(sp - 1)
+                result = _shr_s(val_b, val_a)
+                sp -= 1
+                stack_write(sp, result)
+                top = result
+            elif op == OP_SHR_U:
+                val_a = stack_read(sp)
+                val_b = stack_read(sp - 1)
+                result = _shr_u(val_b, val_a)
+                sp -= 1
+                stack_write(sp, result)
+                top = result
+            elif op == OP_ROTL:
+                val_a = stack_read(sp)
+                val_b = stack_read(sp - 1)
+                result = _rotl32(val_b, val_a)
+                sp -= 1
+                stack_write(sp, result)
+                top = result
+            elif op == OP_ROTR:
+                val_a = stack_read(sp)
+                val_b = stack_read(sp - 1)
+                result = _rotr32(val_b, val_a)
+                sp -= 1
+                stack_write(sp, result)
+                top = result
+
+            # ── Phase 14 Chunk 4: unary + parametric ops ──
+            elif op == OP_CLZ:
+                val_a = stack_read(sp)
+                result = _clz32(val_a)
+                stack_write(sp, result)
+                top = result
+            elif op == OP_CTZ:
+                val_a = stack_read(sp)
+                result = _ctz32(val_a)
+                stack_write(sp, result)
+                top = result
+            elif op == OP_POPCNT:
+                val_a = stack_read(sp)
+                result = _popcnt32(val_a)
+                stack_write(sp, result)
+                top = result
+            elif op == OP_ABS:
+                val_a = stack_read(sp)
+                result = abs(int(val_a))
+                stack_write(sp, result)
+                top = result
+            elif op == OP_NEG:
+                val_a = stack_read(sp)
+                result = -int(val_a)
+                stack_write(sp, result)
+                top = result
+            elif op == OP_SELECT:
+                val_a = stack_read(sp)       # c (condition)
+                val_b = stack_read(sp - 1)   # b (false value)
+                val_c = stack_read(sp - 2)   # a (true value)
+                result = val_c if val_a != 0 else val_b
+                sp -= 2
+                stack_write(sp, result)
+                top = result
+
+            # ── Control flow ──
+            elif op == OP_JZ:
+                cond = stack_read(sp)
+                sp -= 1
+                top = stack_read(sp) if sp > 0 else 0
+                if cond == 0:
+                    next_ip = arg
+            elif op == OP_JNZ:
+                cond = stack_read(sp)
+                sp -= 1
+                top = stack_read(sp) if sp > 0 else 0
+                if cond != 0:
+                    next_ip = arg
+            elif op == OP_NOP:
+                top = stack_read(sp) if sp > 0 else 0
+            elif op == OP_HALT:
+                top = stack_read(sp) if sp > 0 else 0
+                trace.steps.append(TraceStep(op, arg, sp, top))
+                break
+            else:
+                # Unknown opcode — treat as NOP
+                top = stack_read(sp) if sp > 0 else 0
+
+            trace.steps.append(TraceStep(op, arg, sp, top))
+            ip = next_ip
+
+        return trace
+
+
+# ─── Compiled PyTorch Model ──────────────────────────────────────
+
+class CompiledModel(nn.Module):
+    """Compiled transformer with 5 attention heads and linear+nonlinear FF dispatch.
+
+    Flattened from Phase14Model <- Phase13Model <- PerceptaModel.
+
+    Architecture:
+      d_model=36, head_dim=2 (2D parabolic key space)
+      5 active attention heads:
+        Head 0: program opcode fetch
+        Head 1: program arg fetch
+        Head 2: stack read at SP
+        Head 3: stack read at SP-1
+        Head 4: stack read at SP-2
+      FF dispatch:
+        M_top: linear routing matrix (handles PUSH through ROT)
+        Nonlinear override: explicit computation for arith + cmp + bitwise + unary + parametric
+      sp_deltas: per-opcode stack pointer delta
+    """
+
+    def __init__(self, d_model=D_MODEL):
+        nn.Module.__init__(self)
+        self.d_model = d_model
+
+        # Heads 0-4
+        self.head_prog_op  = CompiledAttentionHead(d_model, head_dim=2, v_dim=1)
+        self.head_prog_arg = CompiledAttentionHead(d_model, head_dim=2, v_dim=1)
+        self.head_stack_a  = CompiledAttentionHead(d_model, head_dim=2, v_dim=1)
+        self.head_stack_b  = CompiledAttentionHead(d_model, head_dim=2, v_dim=1, use_bias_q=True)
+        self.head_stack_c  = CompiledAttentionHead(d_model, head_dim=2, v_dim=1, use_bias_q=True)
+
+        # FF dispatch: N_OPCODES opcodes, 4 value inputs
+        self.register_buffer('M_top', torch.zeros(N_OPCODES, 4, dtype=DTYPE))
+        self.register_buffer('sp_deltas', torch.zeros(N_OPCODES, dtype=DTYPE))
+
+        self._compile_weights()
+
+    def _compile_weights(self):
+        """Set all weight matrices analytically."""
+        with torch.no_grad():
+            # ── Head 0: Program opcode fetch ──
+            W = torch.zeros(2, self.d_model)
+            W[0, DIM_IP]  = 1.0
+            W[1, DIM_ONE] = 1.0
+            self.head_prog_op.W_Q.weight.copy_(W)
+
+            W = torch.zeros(2, self.d_model)
+            W[0, DIM_PROG_KEY_0] = 1.0
+            W[1, DIM_PROG_KEY_1] = 1.0
+            self.head_prog_op.W_K.weight.copy_(W)
+
+            W = torch.zeros(1, self.d_model)
+            W[0, DIM_OPCODE] = 1.0
+            self.head_prog_op.W_V.weight.copy_(W)
+
+            # ── Head 1: Program argument fetch ──
+            W = torch.zeros(2, self.d_model)
+            W[0, DIM_IP]  = 1.0
+            W[1, DIM_ONE] = 1.0
+            self.head_prog_arg.W_Q.weight.copy_(W)
+
+            W = torch.zeros(2, self.d_model)
+            W[0, DIM_PROG_KEY_0] = 1.0
+            W[1, DIM_PROG_KEY_1] = 1.0
+            self.head_prog_arg.W_K.weight.copy_(W)
+
+            W = torch.zeros(1, self.d_model)
+            W[0, DIM_VALUE] = 1.0
+            self.head_prog_arg.W_V.weight.copy_(W)
+
+            # ── Head 2: Stack read at SP ──
+            W = torch.zeros(2, self.d_model)
+            W[0, DIM_SP]  = 1.0
+            W[1, DIM_ONE] = 1.0
+            self.head_stack_a.W_Q.weight.copy_(W)
+
+            W = torch.zeros(2, self.d_model)
+            W[0, DIM_STACK_KEY_0] = 1.0
+            W[1, DIM_STACK_KEY_1] = 1.0
+            self.head_stack_a.W_K.weight.copy_(W)
+
+            W = torch.zeros(1, self.d_model)
+            W[0, DIM_VALUE] = 1.0
+            self.head_stack_a.W_V.weight.copy_(W)
+
+            # ── Head 3: Stack read at SP-1 ──
+            W = torch.zeros(2, self.d_model)
+            W[0, DIM_SP]  = 1.0
+            W[1, DIM_ONE] = 1.0
+            self.head_stack_b.W_Q.weight.copy_(W)
+            b = torch.zeros(2)
+            b[0] = -1.0
+            self.head_stack_b.W_Q.bias.copy_(b)
+
+            W = torch.zeros(2, self.d_model)
+            W[0, DIM_STACK_KEY_0] = 1.0
+            W[1, DIM_STACK_KEY_1] = 1.0
+            self.head_stack_b.W_K.weight.copy_(W)
+
+            W = torch.zeros(1, self.d_model)
+            W[0, DIM_VALUE] = 1.0
+            self.head_stack_b.W_V.weight.copy_(W)
+
+            # ── Head 4: Stack read at SP-2 ──
+            W = torch.zeros(2, self.d_model)
+            W[0, DIM_SP]  = 1.0
+            W[1, DIM_ONE] = 1.0
+            self.head_stack_c.W_Q.weight.copy_(W)
+            b = torch.zeros(2)
+            b[0] = -2.0
+            self.head_stack_c.W_Q.bias.copy_(b)
+
+            W = torch.zeros(2, self.d_model)
+            W[0, DIM_STACK_KEY_0] = 1.0
+            W[1, DIM_STACK_KEY_1] = 1.0
+            self.head_stack_c.W_K.weight.copy_(W)
+
+            W = torch.zeros(1, self.d_model)
+            W[0, DIM_VALUE] = 1.0
+            self.head_stack_c.W_V.weight.copy_(W)
+
+            # ── FF dispatch: linear routing ──
+            # M_top maps [arg, val_a, val_b, val_c] -> candidate top per opcode
+            #                         arg  va   vb   vc
+            self.M_top[0]  = torch.tensor([ 1.,  0.,  0.,  0.])  # PUSH: top = arg
+            self.M_top[1]  = torch.tensor([ 0.,  0.,  1.,  0.])  # POP:  top = val_b
+            self.M_top[2]  = torch.tensor([ 0.,  1.,  1.,  0.])  # ADD:  top = va + vb
+            self.M_top[3]  = torch.tensor([ 0.,  1.,  0.,  0.])  # DUP:  top = va
+            self.M_top[4]  = torch.tensor([ 0.,  1.,  0.,  0.])  # HALT: top = va
+            self.M_top[5]  = torch.tensor([ 0., -1.,  1.,  0.])  # SUB:  top = vb - va
+            self.M_top[6]  = torch.tensor([ 0.,  0.,  1.,  0.])  # JZ:   top = vb
+            self.M_top[7]  = torch.tensor([ 0.,  0.,  1.,  0.])  # JNZ:  top = vb
+            self.M_top[8]  = torch.tensor([ 0.,  1.,  0.,  0.])  # NOP:  top = va
+            self.M_top[9]  = torch.tensor([ 0.,  0.,  1.,  0.])  # SWAP: top = vb
+            self.M_top[10] = torch.tensor([ 0.,  0.,  1.,  0.])  # OVER: top = vb
+            self.M_top[11] = torch.tensor([ 0.,  0.,  0.,  1.])  # ROT:  top = vc
+
+            # Nonlinear ops: M_top rows stay zero — results computed in forward()
+
+            # SP deltas
+            self.sp_deltas.copy_(torch.tensor(
+                [1., -1., -1., 1., 0., -1., -1., -1., 0., 0., 1., 0.,
+                 -1., -1., -1., -1., -1.,
+                 0.,  -1., -1., -1., -1., -1., -1., -1., -1., -1., -1.,
+                 -1., -1., -1., -1., -1., -1., -1., -1.,
+                 0., 0., 0., 0., 0., -2.]))
+
+    def forward(self, query_emb, prog_embs, stack_embs):
+        """Execute one step.
+
+        Returns (opcode, arg, sp_delta, top, opcode_one_hot, val_a, val_b, val_c).
+        """
+        # Head 0: Fetch opcode
+        opcode_val, _, _ = self.head_prog_op(query_emb, prog_embs)
+        # Head 1: Fetch argument
+        arg_val, _, _ = self.head_prog_arg(query_emb, prog_embs)
+
+        # Head 2: Read stack[SP]
+        if stack_embs.shape[0] > 0:
+            val_a_raw, _, idx_a = self.head_stack_a(query_emb, stack_embs)
+            stored_addr_a = round(stack_embs[idx_a, DIM_STACK_KEY_0].item() / 2.0)
+            queried_sp = round(query_emb[DIM_SP].item())
+            val_a = val_a_raw[0] if stored_addr_a == queried_sp else torch.tensor(0.0, dtype=DTYPE)
+        else:
+            val_a = torch.tensor(0.0, dtype=DTYPE)
+
+        # Head 3: Read stack[SP-1]
+        if stack_embs.shape[0] > 0:
+            val_b_raw, _, idx_b = self.head_stack_b(query_emb, stack_embs)
+            stored_addr_b = round(stack_embs[idx_b, DIM_STACK_KEY_0].item() / 2.0)
+            queried_sp_m1 = round(query_emb[DIM_SP].item()) - 1
+            val_b = val_b_raw[0] if stored_addr_b == queried_sp_m1 else torch.tensor(0.0, dtype=DTYPE)
+        else:
+            val_b = torch.tensor(0.0, dtype=DTYPE)
+
+        # Head 4: Read stack[SP-2]
+        if stack_embs.shape[0] > 0:
+            val_c_raw, _, idx_c = self.head_stack_c(query_emb, stack_embs)
+            stored_addr_c = round(stack_embs[idx_c, DIM_STACK_KEY_0].item() / 2.0)
+            queried_sp_m2 = round(query_emb[DIM_SP].item()) - 2
+            val_c = val_c_raw[0] if stored_addr_c == queried_sp_m2 else torch.tensor(0.0, dtype=DTYPE)
+        else:
+            val_c = torch.tensor(0.0, dtype=DTYPE)
+
+        # Decode
+        opcode = round(opcode_val[0].item())
+        arg = round(arg_val[0].item())
+
+        # FF Dispatch — linear path
+        opcode_one_hot = torch.zeros(N_OPCODES, dtype=DTYPE)
+        idx = OPCODE_IDX.get(opcode, -1)
+        if idx >= 0:
+            opcode_one_hot[idx] = 1.0
+
+        values = torch.stack([
+            torch.tensor(float(arg), dtype=DTYPE),
+            val_a, val_b, val_c
+        ])
+        candidates = self.M_top @ values
+        top_linear = (opcode_one_hot * candidates).sum()
+
+        # FF Dispatch — nonlinear path
+        va = round(val_a.item())
+        vb = round(val_b.item())
+
+        nonlinear = torch.zeros(N_OPCODES, dtype=DTYPE)
+        nonlinear[OPCODE_IDX[OP_MUL]] = float(va * vb)
+        if va != 0:
+            nonlinear[OPCODE_IDX[OP_DIV_S]] = float(_trunc_div(vb, va))
+            nonlinear[OPCODE_IDX[OP_DIV_U]] = float(_trunc_div(vb, va))
+            nonlinear[OPCODE_IDX[OP_REM_S]] = float(_trunc_rem(vb, va))
+            nonlinear[OPCODE_IDX[OP_REM_U]] = float(_trunc_rem(vb, va))
+
+        # Comparison ops
+        nonlinear[OPCODE_IDX[OP_EQZ]]  = 1.0 if va == 0 else 0.0
+        nonlinear[OPCODE_IDX[OP_EQ]]   = 1.0 if va == vb else 0.0
+        nonlinear[OPCODE_IDX[OP_NE]]   = 1.0 if va != vb else 0.0
+        nonlinear[OPCODE_IDX[OP_LT_S]] = 1.0 if vb < va else 0.0
+        nonlinear[OPCODE_IDX[OP_LT_U]] = 1.0 if vb < va else 0.0
+        nonlinear[OPCODE_IDX[OP_GT_S]] = 1.0 if vb > va else 0.0
+        nonlinear[OPCODE_IDX[OP_GT_U]] = 1.0 if vb > va else 0.0
+        nonlinear[OPCODE_IDX[OP_LE_S]] = 1.0 if vb <= va else 0.0
+        nonlinear[OPCODE_IDX[OP_LE_U]] = 1.0 if vb <= va else 0.0
+        nonlinear[OPCODE_IDX[OP_GE_S]] = 1.0 if vb >= va else 0.0
+        nonlinear[OPCODE_IDX[OP_GE_U]] = 1.0 if vb >= va else 0.0
+
+        # Bitwise ops
+        nonlinear[OPCODE_IDX[OP_AND]]   = float(_to_i32(va) & _to_i32(vb))
+        nonlinear[OPCODE_IDX[OP_OR]]    = float(_to_i32(va) | _to_i32(vb))
+        nonlinear[OPCODE_IDX[OP_XOR]]   = float(_to_i32(va) ^ _to_i32(vb))
+        nonlinear[OPCODE_IDX[OP_SHL]]   = float((_to_i32(vb) << (int(va) & 31)) & MASK32)
+        nonlinear[OPCODE_IDX[OP_SHR_S]] = float(_shr_s(vb, va))
+        nonlinear[OPCODE_IDX[OP_SHR_U]] = float(_shr_u(vb, va))
+        nonlinear[OPCODE_IDX[OP_ROTL]]  = float(_rotl32(vb, va))
+        nonlinear[OPCODE_IDX[OP_ROTR]]  = float(_rotr32(vb, va))
+
+        # Unary ops
+        nonlinear[OPCODE_IDX[OP_CLZ]]    = float(_clz32(va))
+        nonlinear[OPCODE_IDX[OP_CTZ]]    = float(_ctz32(va))
+        nonlinear[OPCODE_IDX[OP_POPCNT]] = float(_popcnt32(va))
+        nonlinear[OPCODE_IDX[OP_ABS]]    = float(abs(int(va)))
+        nonlinear[OPCODE_IDX[OP_NEG]]    = float(-int(va))
+
+        # Parametric: SELECT
+        vc = round(val_c.item())
+        nonlinear[OPCODE_IDX[OP_SELECT]] = float(vc if va != 0 else vb)
+
+        top_nonlinear = (opcode_one_hot * nonlinear).sum()
+        top = top_linear + top_nonlinear
+
+        sp_delta = (opcode_one_hot * self.sp_deltas).sum()
+
+        return (opcode, arg, int(sp_delta.item()), round(top.item()),
+                opcode_one_hot, round(val_a.item()), round(val_b.item()), round(val_c.item()))
+
+
+# ─── PyTorch Executor ────────────────────────────────────────────
+
+class TorchExecutor:
+    """Executes programs using CompiledModel.
+
+    Flattened from Phase14PyTorchExecutor.
+    """
+
+    def __init__(self, model=None):
+        self.model = model or CompiledModel()
+        self.model.eval()
+
+    def execute(self, prog, max_steps=5000):
+        trace = Trace(program=prog)
+
+        prog_embs = torch.stack([
+            embed_program_token(i, instr)
+            for i, instr in enumerate(prog)
+        ])
+
+        stack_embs_list = []
+        write_count = 0
+        ip = 0
+        sp = 0
+
+        with torch.no_grad():
+            for step in range(max_steps):
+                if ip >= len(prog):
+                    break
+
+                query = embed_state(ip, sp)
+                stack_embs = (torch.stack(stack_embs_list)
+                              if stack_embs_list
+                              else torch.zeros(0, D_MODEL, dtype=DTYPE))
+
+                opcode, arg, sp_delta, top, _, val_a, val_b, val_c = \
+                    self.model.forward(query, prog_embs, stack_embs)
+
+                if opcode == OP_HALT:
+                    trace.steps.append(TraceStep(opcode, arg, sp, top))
+                    break
+
+                # Trap: division by zero
+                if opcode in (OP_DIV_S, OP_DIV_U, OP_REM_S, OP_REM_U) and val_a == 0:
+                    trace.steps.append(TraceStep(OP_TRAP, 0, sp, 0))
+                    break
+
+                # For JZ/JNZ: read condition BEFORE updating SP
+                cond_val = None
+                if opcode in (OP_JZ, OP_JNZ):
+                    cond_val = val_a
+
+                new_sp = sp + sp_delta
+
+                # Stack writes per opcode
+                if opcode in (OP_PUSH, OP_DUP, OP_OVER):
+                    stack_embs_list.append(
+                        embed_stack_entry(new_sp, top, write_count))
+                    write_count += 1
+                elif opcode in (OP_ADD, OP_SUB, OP_MUL, OP_DIV_S, OP_DIV_U,
+                                OP_REM_S, OP_REM_U,
+                                OP_EQ, OP_NE,
+                                OP_LT_S, OP_LT_U, OP_GT_S, OP_GT_U,
+                                OP_LE_S, OP_LE_U, OP_GE_S, OP_GE_U,
+                                OP_AND, OP_OR, OP_XOR,
+                                OP_SHL, OP_SHR_S, OP_SHR_U,
+                                OP_ROTL, OP_ROTR):
+                    stack_embs_list.append(
+                        embed_stack_entry(new_sp, top, write_count))
+                    write_count += 1
+                elif opcode in (OP_EQZ, OP_CLZ, OP_CTZ, OP_POPCNT, OP_ABS, OP_NEG):
+                    stack_embs_list.append(
+                        embed_stack_entry(new_sp, top, write_count))
+                    write_count += 1
+                elif opcode == OP_SELECT:
+                    stack_embs_list.append(
+                        embed_stack_entry(new_sp, top, write_count))
+                    write_count += 1
+                elif opcode == OP_SWAP:
+                    stack_embs_list.append(
+                        embed_stack_entry(sp, val_b, write_count))
+                    write_count += 1
+                    stack_embs_list.append(
+                        embed_stack_entry(sp - 1, val_a, write_count))
+                    write_count += 1
+                elif opcode == OP_ROT:
+                    stack_embs_list.append(
+                        embed_stack_entry(sp, val_c, write_count))
+                    write_count += 1
+                    stack_embs_list.append(
+                        embed_stack_entry(sp - 1, val_a, write_count))
+                    write_count += 1
+                    stack_embs_list.append(
+                        embed_stack_entry(sp - 2, val_b, write_count))
+                    write_count += 1
+
+                trace.steps.append(TraceStep(opcode, arg, new_sp, top))
+                sp = new_sp
+
+                # IP update
+                if opcode == OP_JZ:
+                    ip = arg if cond_val == 0 else ip + 1
+                elif opcode == OP_JNZ:
+                    ip = arg if cond_val != 0 else ip + 1
+                else:
+                    ip += 1
+
+        return trace

--- a/isa.py
+++ b/isa.py
@@ -1,0 +1,500 @@
+"""ISA definition for the compiled transformer stack machine.
+
+Consolidated from phase4, phase12, phase13, phase14. Contains:
+  - Types: Instruction, Trace, TraceStep
+  - Constants: D_MODEL, DTYPE, EPS, N_OPCODES, all DIM_* layout
+  - Opcodes: OP_PUSH through OP_SELECT, OP_TRAP
+  - Maps: OP_NAMES, OPCODE_DIM_MAP, OPCODE_IDX, NONLINEAR_OPS
+  - Math helpers: _trunc_div, _trunc_rem, bitwise ops
+  - CompiledAttentionHead: nn.Module for hard-max attention
+  - Embedding functions: embed_program_token, embed_stack_entry, embed_state
+  - Test utilities: compare_traces, test_algorithm, test_trap_algorithm
+"""
+
+import numpy as np
+import torch
+import torch.nn as nn
+from typing import List, Optional
+from dataclasses import dataclass, field
+
+
+# ─── Types (from phase4) ──────────────────────────────────────────
+
+@dataclass
+class Instruction:
+    op: int
+    arg: int = 0
+
+    def __repr__(self):
+        name = OP_NAMES.get(self.op, f"?{self.op}")
+        if self.op == OP_PUSH:
+            return f"{name} {self.arg}"
+        return name
+
+
+def program(*instrs) -> List[Instruction]:
+    """Convenience: program(('PUSH', 3), ('PUSH', 5), ('ADD',), ('HALT',))"""
+    result = []
+    _name_to_op = {
+        "PUSH": 1, "POP": 2, "ADD": 3, "DUP": 4, "HALT": 5,
+        "SUB": 6, "JZ": 7, "JNZ": 8, "NOP": 9,
+        "SWAP": 10, "OVER": 11, "ROT": 12,
+        "MUL": 13, "DIV_S": 14, "DIV_U": 15, "REM_S": 16, "REM_U": 17,
+        "EQZ": 18, "EQ": 19, "NE": 20,
+        "LT_S": 21, "LT_U": 22, "GT_S": 23, "GT_U": 24,
+        "LE_S": 25, "LE_U": 26, "GE_S": 27, "GE_U": 28,
+        "AND": 29, "OR": 30, "XOR": 31,
+        "SHL": 32, "SHR_S": 33, "SHR_U": 34, "ROTL": 35, "ROTR": 36,
+        "CLZ": 37, "CTZ": 38, "POPCNT": 39, "ABS": 40, "NEG": 41,
+        "SELECT": 42,
+    }
+    for instr in instrs:
+        if isinstance(instr, Instruction):
+            result.append(instr)
+            continue
+        name = instr[0].upper()
+        arg = instr[1] if len(instr) > 1 else 0
+        op = _name_to_op[name]
+        result.append(Instruction(op, arg))
+    return result
+
+
+@dataclass
+class TraceStep:
+    """One instruction's execution record."""
+    op: int
+    arg: int
+    sp: int      # stack pointer AFTER execution
+    top: int     # top-of-stack value AFTER execution
+
+    def tokens(self) -> List[int]:
+        return [self.op, self.arg, self.sp, self.top]
+
+
+@dataclass
+class Trace:
+    """Full execution trace: program prefix + step records."""
+    program: List[Instruction]
+    steps: List[TraceStep] = field(default_factory=list)
+
+    def format_trace(self) -> str:
+        """Human-readable trace."""
+        lines = []
+        lines.append(f"Program: {' ; '.join(str(i) for i in self.program)}")
+        lines.append(f"{'Step':>4}  {'Instruction':<10} {'SP':>3}  {'TOP':>5}")
+        lines.append("-" * 35)
+        for i, s in enumerate(self.steps):
+            name = OP_NAMES.get(s.op, "?")
+            instr_str = f"{name} {s.arg}" if s.op == OP_PUSH else name
+            lines.append(f"{i:4d}  {instr_str:<10} {s.sp:3d}  {s.top:5d}")
+        return "\n".join(lines)
+
+
+# ─── Constants ────────────────────────────────────────────────────
+
+D_MODEL = 36
+DTYPE = torch.float64
+EPS = 1e-6
+
+# Token roles (from phase4, used in training phases)
+TOKENS_PER_STEP = 4
+
+
+# ─── Embedding Dimension Layout (all 36 dims) ────────────────────
+
+DIM_IS_PROG     = 0
+DIM_IS_STACK    = 1
+DIM_IS_STATE    = 2
+DIM_PROG_KEY_0  = 3
+DIM_PROG_KEY_1  = 4
+DIM_STACK_KEY_0 = 5
+DIM_STACK_KEY_1 = 6
+DIM_OPCODE      = 7
+DIM_VALUE       = 8
+DIM_IP          = 9
+DIM_SP          = 10
+DIM_ONE         = 11
+DIM_IS_PUSH     = 12
+DIM_IS_POP      = 13
+DIM_IS_ADD      = 14
+DIM_IS_DUP      = 15
+DIM_IS_HALT     = 16
+DIM_IS_SUB      = 17
+DIM_IS_JZ       = 18
+DIM_IS_JNZ      = 19
+DIM_IS_NOP      = 20
+DIM_IS_SWAP     = 21
+DIM_IS_OVER     = 22
+DIM_IS_ROT      = 23
+DIM_IS_MUL      = 24
+DIM_IS_DIV_S    = 25
+DIM_IS_DIV_U    = 26
+DIM_IS_REM_S    = 27
+DIM_IS_REM_U    = 28
+DIM_IS_EQZ      = 29
+DIM_IS_EQ       = 30
+DIM_IS_NE       = 31
+DIM_IS_LT       = 32   # shared by LT_S and LT_U
+DIM_IS_GT       = 33   # shared by GT_S and GT_U
+DIM_IS_LE       = 34   # shared by LE_S and LE_U
+DIM_IS_GE       = 35   # shared by GE_S and GE_U
+
+
+# ─── Opcodes ─────────────────────────────────────────────────────
+
+# Phase 4 base
+OP_PUSH = 1
+OP_POP  = 2
+OP_ADD  = 3
+OP_DUP  = 4
+OP_HALT = 5
+
+# Phase 11 extended
+OP_SUB = 6
+OP_JZ  = 7
+OP_JNZ = 8
+OP_NOP = 9
+
+# Phase 13 stack manipulation
+OP_SWAP = 10
+OP_OVER = 11
+OP_ROT  = 12
+
+# Phase 14 Chunk 1: arithmetic
+OP_MUL   = 13
+OP_DIV_S = 14
+OP_DIV_U = 15
+OP_REM_S = 16
+OP_REM_U = 17
+
+# Phase 14 Chunk 2: comparisons
+OP_EQZ   = 18
+OP_EQ    = 19
+OP_NE    = 20
+OP_LT_S  = 21
+OP_LT_U  = 22
+OP_GT_S  = 23
+OP_GT_U  = 24
+OP_LE_S  = 25
+OP_LE_U  = 26
+OP_GE_S  = 27
+OP_GE_U  = 28
+
+# Phase 14 Chunk 3: bitwise
+OP_AND   = 29
+OP_OR    = 30
+OP_XOR   = 31
+OP_SHL   = 32
+OP_SHR_S = 33
+OP_SHR_U = 34
+OP_ROTL  = 35
+OP_ROTR  = 36
+
+# Phase 14 Chunk 4: unary + parametric
+OP_CLZ    = 37
+OP_CTZ    = 38
+OP_POPCNT = 39
+OP_ABS    = 40
+OP_NEG    = 41
+OP_SELECT = 42
+
+# Trap
+OP_TRAP  = 99
+
+N_OPCODES = 42  # 12 base + 5 arith + 11 cmp + 8 bitwise + 5 unary + 1 parametric
+
+
+# ─── Maps ─────────────────────────────────────────────────────────
+
+OP_NAMES = {
+    OP_PUSH: "PUSH", OP_POP: "POP", OP_ADD: "ADD", OP_DUP: "DUP", OP_HALT: "HALT",
+    OP_SUB: "SUB", OP_JZ: "JZ", OP_JNZ: "JNZ", OP_NOP: "NOP",
+    OP_SWAP: "SWAP", OP_OVER: "OVER", OP_ROT: "ROT",
+    OP_MUL: "MUL", OP_DIV_S: "DIV_S", OP_DIV_U: "DIV_U",
+    OP_REM_S: "REM_S", OP_REM_U: "REM_U",
+    OP_EQZ: "EQZ", OP_EQ: "EQ", OP_NE: "NE",
+    OP_LT_S: "LT_S", OP_LT_U: "LT_U", OP_GT_S: "GT_S", OP_GT_U: "GT_U",
+    OP_LE_S: "LE_S", OP_LE_U: "LE_U", OP_GE_S: "GE_S", OP_GE_U: "GE_U",
+    OP_AND: "AND", OP_OR: "OR", OP_XOR: "XOR",
+    OP_SHL: "SHL", OP_SHR_S: "SHR_S", OP_SHR_U: "SHR_U",
+    OP_ROTL: "ROTL", OP_ROTR: "ROTR",
+    OP_CLZ: "CLZ", OP_CTZ: "CTZ", OP_POPCNT: "POPCNT",
+    OP_ABS: "ABS", OP_NEG: "NEG", OP_SELECT: "SELECT",
+    OP_TRAP: "TRAP",
+}
+
+OPCODE_DIM_MAP = {
+    OP_PUSH: DIM_IS_PUSH, OP_POP: DIM_IS_POP, OP_ADD: DIM_IS_ADD,
+    OP_DUP: DIM_IS_DUP, OP_HALT: DIM_IS_HALT, OP_SUB: DIM_IS_SUB,
+    OP_JZ: DIM_IS_JZ, OP_JNZ: DIM_IS_JNZ, OP_NOP: DIM_IS_NOP,
+    OP_SWAP: DIM_IS_SWAP, OP_OVER: DIM_IS_OVER, OP_ROT: DIM_IS_ROT,
+    OP_MUL: DIM_IS_MUL, OP_DIV_S: DIM_IS_DIV_S, OP_DIV_U: DIM_IS_DIV_U,
+    OP_REM_S: DIM_IS_REM_S, OP_REM_U: DIM_IS_REM_U,
+    OP_EQZ: DIM_IS_EQZ, OP_EQ: DIM_IS_EQ, OP_NE: DIM_IS_NE,
+    OP_LT_S: DIM_IS_LT, OP_LT_U: DIM_IS_LT,
+    OP_GT_S: DIM_IS_GT, OP_GT_U: DIM_IS_GT,
+    OP_LE_S: DIM_IS_LE, OP_LE_U: DIM_IS_LE,
+    OP_GE_S: DIM_IS_GE, OP_GE_U: DIM_IS_GE,
+}
+
+OPCODE_IDX = {
+    OP_PUSH: 0, OP_POP: 1, OP_ADD: 2, OP_DUP: 3, OP_HALT: 4,
+    OP_SUB: 5, OP_JZ: 6, OP_JNZ: 7, OP_NOP: 8,
+    OP_SWAP: 9, OP_OVER: 10, OP_ROT: 11,
+    OP_MUL: 12, OP_DIV_S: 13, OP_DIV_U: 14, OP_REM_S: 15, OP_REM_U: 16,
+    OP_EQZ: 17, OP_EQ: 18, OP_NE: 19,
+    OP_LT_S: 20, OP_LT_U: 21, OP_GT_S: 22, OP_GT_U: 23,
+    OP_LE_S: 24, OP_LE_U: 25, OP_GE_S: 26, OP_GE_U: 27,
+    OP_AND: 28, OP_OR: 29, OP_XOR: 30,
+    OP_SHL: 31, OP_SHR_S: 32, OP_SHR_U: 33, OP_ROTL: 34, OP_ROTR: 35,
+    OP_CLZ: 36, OP_CTZ: 37, OP_POPCNT: 38, OP_ABS: 39, OP_NEG: 40,
+    OP_SELECT: 41,
+}
+
+NONLINEAR_OPS = {
+    OP_MUL, OP_DIV_S, OP_DIV_U, OP_REM_S, OP_REM_U,
+    OP_EQZ, OP_EQ, OP_NE,
+    OP_LT_S, OP_LT_U, OP_GT_S, OP_GT_U,
+    OP_LE_S, OP_LE_U, OP_GE_S, OP_GE_U,
+    OP_AND, OP_OR, OP_XOR,
+    OP_SHL, OP_SHR_S, OP_SHR_U,
+    OP_ROTL, OP_ROTR,
+    OP_CLZ, OP_CTZ, OP_POPCNT, OP_ABS, OP_NEG, OP_SELECT,
+}
+
+
+# ─── Math Helpers ─────────────────────────────────────────────────
+
+MASK32 = 0xFFFFFFFF
+
+
+def _trunc_div(b, a):
+    """Signed integer division truncating toward zero (WASM semantics)."""
+    return int(b / a)
+
+
+def _trunc_rem(b, a):
+    """Signed remainder matching truncated division: b - trunc(b/a)*a."""
+    return b - _trunc_div(b, a) * a
+
+
+def _to_i32(val):
+    """Cast to 32-bit signed integer from potentially float stack value."""
+    return int(val) & MASK32
+
+
+def _shr_u(b, a):
+    """Logical (unsigned) right shift of b by a positions."""
+    return (_to_i32(b) >> (int(a) & 31))
+
+
+def _shr_s(b, a):
+    """Arithmetic (signed) right shift of b by a positions."""
+    val = _to_i32(b)
+    if val >= 0x80000000:
+        val -= 0x100000000
+    shift = int(a) & 31
+    result = val >> shift
+    return result & MASK32 if result < 0 else result
+
+
+def _rotl32(b, a):
+    """Left-rotate b by a positions within 32-bit word."""
+    val = _to_i32(b)
+    shift = int(a) & 31
+    return ((val << shift) | (val >> (32 - shift))) & MASK32 if shift else val
+
+
+def _rotr32(b, a):
+    """Right-rotate b by a positions within 32-bit word."""
+    val = _to_i32(b)
+    shift = int(a) & 31
+    return ((val >> shift) | (val << (32 - shift))) & MASK32 if shift else val
+
+
+def _clz32(val):
+    """Count leading zeros in 32-bit representation."""
+    v = _to_i32(val)
+    if v == 0:
+        return 32
+    n = 0
+    if v <= 0x0000FFFF: n += 16; v <<= 16
+    if v <= 0x00FFFFFF: n += 8;  v <<= 8
+    if v <= 0x0FFFFFFF: n += 4;  v <<= 4
+    if v <= 0x3FFFFFFF: n += 2;  v <<= 2
+    if v <= 0x7FFFFFFF: n += 1
+    return n
+
+
+def _ctz32(val):
+    """Count trailing zeros in 32-bit representation."""
+    v = _to_i32(val)
+    if v == 0:
+        return 32
+    n = 0
+    if (v & 0x0000FFFF) == 0: n += 16; v >>= 16
+    if (v & 0x000000FF) == 0: n += 8;  v >>= 8
+    if (v & 0x0000000F) == 0: n += 4;  v >>= 4
+    if (v & 0x00000003) == 0: n += 2;  v >>= 2
+    if (v & 0x00000001) == 0: n += 1
+    return n
+
+
+def _popcnt32(val):
+    """Population count (number of set bits) in 32-bit representation."""
+    return bin(_to_i32(val)).count('1')
+
+
+# ─── Compiled Attention Head (from phase12) ───────────────────────
+
+class CompiledAttentionHead(nn.Module):
+    """Hard-max attention head with analytically set W_Q, W_K, W_V.
+
+    Computes:
+      q = W_Q @ query_embedding           (head_dim,)
+      K = W_K @ memory_embeddings          (N, head_dim)
+      V = W_V @ memory_embeddings          (N, v_dim)
+      scores = K @ q                       (N,)
+      output = V[argmax(scores)]           (v_dim,)
+
+    head_dim=2 for parabolic key space.
+    v_dim=1 for scalar value extraction.
+    """
+
+    def __init__(self, d_model=D_MODEL, head_dim=2, v_dim=1, use_bias_q=False):
+        super().__init__()
+        self.W_Q = nn.Linear(d_model, head_dim, bias=use_bias_q)
+        self.W_K = nn.Linear(d_model, head_dim, bias=False)
+        self.W_V = nn.Linear(d_model, v_dim, bias=False)
+        self.double()
+
+    def forward(self, query_emb, memory_embs):
+        """Hard-max attention lookup.
+
+        Args:
+            query_emb: (D,) single query embedding (float64)
+            memory_embs: (N, D) memory entries to attend over (float64)
+
+        Returns:
+            value: (v_dim,) extracted from the best-matching entry
+            score: scalar, the winning attention score
+            idx: int, the index of the selected entry
+        """
+        if memory_embs.shape[0] == 0:
+            return torch.zeros(self.W_V.out_features, dtype=DTYPE), \
+                   torch.tensor(-float('inf'), dtype=DTYPE), -1
+
+        q = self.W_Q(query_emb)
+        K = self.W_K(memory_embs)
+        V = self.W_V(memory_embs)
+
+        scores = K @ q
+        best = scores.argmax().item()
+
+        return V[best], scores[best], best
+
+
+# ─── Embedding Functions (phase14 versions with OPCODE_DIM_MAP) ──
+
+def embed_program_token(pos, instr):
+    """Create 36-dim embedding for a program instruction."""
+    emb = torch.zeros(D_MODEL, dtype=DTYPE)
+    emb[DIM_IS_PROG]     = 1.0
+    emb[DIM_PROG_KEY_0]  = 2.0 * pos
+    emb[DIM_PROG_KEY_1]  = -float(pos * pos)
+    emb[DIM_OPCODE]      = float(instr.op)
+    emb[DIM_VALUE]       = float(instr.arg)
+    emb[DIM_ONE]         = 1.0
+    dim = OPCODE_DIM_MAP.get(instr.op)
+    if dim is not None:
+        emb[dim] = 1.0
+    return emb
+
+
+def embed_stack_entry(addr, value, write_order):
+    """Create 36-dim embedding for a stack write record."""
+    emb = torch.zeros(D_MODEL, dtype=DTYPE)
+    emb[DIM_IS_STACK]     = 1.0
+    emb[DIM_STACK_KEY_0]  = 2.0 * addr
+    emb[DIM_STACK_KEY_1]  = -float(addr * addr) + EPS * write_order
+    emb[DIM_VALUE]        = float(value)
+    emb[DIM_ONE]          = 1.0
+    return emb
+
+
+def embed_state(ip, sp):
+    """Create 36-dim query embedding encoding current execution state."""
+    emb = torch.zeros(D_MODEL, dtype=DTYPE)
+    emb[DIM_IS_STATE] = 1.0
+    emb[DIM_IP]       = float(ip)
+    emb[DIM_SP]       = float(sp)
+    emb[DIM_ONE]      = 1.0
+    return emb
+
+
+# ─── Test Utilities (from phase13/phase14) ────────────────────────
+
+def compare_traces(trace_a, trace_b):
+    """Compare two traces token by token. Returns (match: bool, detail: str)."""
+    if len(trace_a.steps) != len(trace_b.steps):
+        return False, f"length mismatch: {len(trace_a.steps)} vs {len(trace_b.steps)}"
+    for i, (a, b) in enumerate(zip(trace_a.steps, trace_b.steps)):
+        if a.tokens() != b.tokens():
+            return False, f"step {i}: {a.tokens()} vs {b.tokens()}"
+    return True, "match"
+
+
+def test_algorithm(name, prog, expected, np_exec, pt_exec, verbose=False):
+    """Run an algorithm on both executors and verify."""
+    np_trace = np_exec.execute(prog)
+    pt_trace = pt_exec.execute(prog)
+
+    np_top = np_trace.steps[-1].top if np_trace.steps else None
+    pt_top = pt_trace.steps[-1].top if pt_trace.steps else None
+    match, detail = compare_traces(np_trace, pt_trace)
+
+    np_ok = (np_top == expected)
+    pt_ok = (pt_top == expected)
+    all_ok = np_ok and pt_ok and match
+
+    status = "PASS" if all_ok else "FAIL"
+    print(f"  {status}  {name:30s}  expected={expected:>6}  "
+          f"numpy={np_top:>6}  torch={pt_top:>6}  "
+          f"steps={len(np_trace.steps):>4}  trace_match={'Y' if match else 'N'}")
+
+    if not all_ok and verbose:
+        if not match:
+            print(f"         Trace mismatch: {detail}")
+        if not np_ok:
+            print(f"         NumPy wrong: got {np_top}, expected {expected}")
+        if not pt_ok:
+            print(f"         PyTorch wrong: got {pt_top}, expected {expected}")
+
+    return all_ok, len(np_trace.steps)
+
+
+def test_trap_algorithm(name, prog, np_exec, pt_exec, verbose=False):
+    """Run a program expected to TRAP on both executors. Returns True if both trap."""
+    np_trace = np_exec.execute(prog)
+    pt_trace = pt_exec.execute(prog)
+
+    np_trapped = np_trace.steps and np_trace.steps[-1].op == OP_TRAP
+    pt_trapped = pt_trace.steps and pt_trace.steps[-1].op == OP_TRAP
+    match, detail = compare_traces(np_trace, pt_trace)
+    all_ok = np_trapped and pt_trapped and match
+
+    status = "PASS" if all_ok else "FAIL"
+    np_label = f"TRAP@{len(np_trace.steps)}" if np_trapped else f"top={np_trace.steps[-1].top if np_trace.steps else '?'}"
+    pt_label = f"TRAP@{len(pt_trace.steps)}" if pt_trapped else f"top={pt_trace.steps[-1].top if pt_trace.steps else '?'}"
+    print(f"  {status}  {name:30s}  numpy={np_label:>10}  torch={pt_label:>10}  "
+          f"trace_match={'Y' if match else 'N'}")
+
+    if not all_ok and verbose:
+        if not np_trapped:
+            print(f"         NumPy did not trap")
+        if not pt_trapped:
+            print(f"         PyTorch did not trap")
+        if not match:
+            print(f"         Trace mismatch: {detail}")
+
+    return all_ok

--- a/programs.py
+++ b/programs.py
@@ -1,0 +1,625 @@
+"""Program generators for the compiled transformer stack machine.
+
+Consolidated from phase4, phase13, phase14. Contains all test program
+generators and the ALL_TESTS regression list.
+"""
+
+import math
+
+from isa import (
+    Instruction,
+    OP_PUSH, OP_POP, OP_ADD, OP_DUP, OP_HALT,
+    OP_SUB, OP_JZ, OP_JNZ, OP_NOP,
+    OP_SWAP, OP_OVER, OP_ROT,
+    OP_MUL, OP_DIV_S, OP_DIV_U, OP_REM_S, OP_REM_U,
+    OP_EQZ, OP_EQ, OP_NE,
+    OP_LT_S, OP_LT_U, OP_GT_S, OP_GT_U,
+    OP_LE_S, OP_LE_U, OP_GE_S, OP_GE_U,
+    OP_AND, OP_OR, OP_XOR,
+    OP_SHL, OP_SHR_S, OP_SHR_U, OP_ROTL, OP_ROTR,
+    OP_CLZ, OP_CTZ, OP_POPCNT, OP_ABS, OP_NEG, OP_SELECT,
+    _trunc_div, _trunc_rem, _to_i32, MASK32,
+    _shr_u, _shr_s, _rotl32, _rotr32,
+    _clz32, _ctz32, _popcnt32,
+    program,
+)
+
+
+# ─── Phase 4 Test Programs ──────────────────────────────────────
+
+def test_basic():
+    """PUSH 3, PUSH 5, ADD, HALT -> top should be 8."""
+    prog = program(("PUSH", 3), ("PUSH", 5), ("ADD",), ("HALT",))
+    return prog, 8
+
+def test_push_halt():
+    """PUSH 42, HALT -> top should be 42."""
+    prog = program(("PUSH", 42), ("HALT",))
+    return prog, 42
+
+def test_push_pop():
+    """PUSH 10, PUSH 20, POP, HALT -> top should be 10."""
+    prog = program(("PUSH", 10), ("PUSH", 20), ("POP",), ("HALT",))
+    return prog, 10
+
+def test_dup_add():
+    """PUSH 7, DUP, ADD, HALT -> top should be 14."""
+    prog = program(("PUSH", 7), ("DUP",), ("ADD",), ("HALT",))
+    return prog, 14
+
+def test_multi_add():
+    """PUSH 1, PUSH 2, PUSH 3, ADD, ADD, HALT -> top should be 6."""
+    prog = program(("PUSH", 1), ("PUSH", 2), ("PUSH", 3), ("ADD",), ("ADD",), ("HALT",))
+    return prog, 6
+
+def test_stack_depth():
+    """PUSH 1, PUSH 2, PUSH 3, POP, POP, HALT -> top should be 1."""
+    prog = program(("PUSH", 1), ("PUSH", 2), ("PUSH", 3), ("POP",), ("POP",), ("HALT",))
+    return prog, 1
+
+def test_overwrite():
+    """PUSH 5, POP, PUSH 9, HALT -> top should be 9."""
+    prog = program(("PUSH", 5), ("POP",), ("PUSH", 9), ("HALT",))
+    return prog, 9
+
+def test_complex():
+    """PUSH 10, PUSH 20, PUSH 30, ADD, DUP, ADD, HALT -> 100."""
+    prog = program(("PUSH", 10), ("PUSH", 20), ("PUSH", 30),
+                   ("ADD",), ("DUP",), ("ADD",), ("HALT",))
+    return prog, 100
+
+def test_many_pushes():
+    """Push values 1..10, then ADD them all."""
+    instrs = [("PUSH", i) for i in range(1, 11)]
+    instrs += [("ADD",)] * 9
+    instrs.append(("HALT",))
+    prog = program(*instrs)
+    return prog, 55
+
+def test_alternating():
+    """PUSH 1, PUSH 2, ADD, PUSH 3, ADD, PUSH 4, ADD, HALT -> 10."""
+    prog = program(("PUSH", 1), ("PUSH", 2), ("ADD",),
+                   ("PUSH", 3), ("ADD",),
+                   ("PUSH", 4), ("ADD",), ("HALT",))
+    return prog, 10
+
+
+ALL_TESTS = [
+    ("basic_add",      test_basic),
+    ("push_halt",      test_push_halt),
+    ("push_pop",       test_push_pop),
+    ("dup_add",        test_dup_add),
+    ("multi_add",      test_multi_add),
+    ("stack_depth",    test_stack_depth),
+    ("overwrite",      test_overwrite),
+    ("complex",        test_complex),
+    ("many_pushes",    test_many_pushes),
+    ("alternating",    test_alternating),
+]
+
+
+# ─── Phase 13 Algorithm Generators ──────────────────────────────
+
+def fib(n):
+    """Reference Fibonacci."""
+    if n <= 0: return 0
+    a, b = 0, 1
+    for _ in range(n - 1):
+        a, b = b, a + b
+    return b
+
+
+def make_fibonacci(n):
+    """Generate a program that computes fib(n).
+
+    Algorithm: iterative [counter, a, b] -> SWAP, OVER, ADD -> [counter, b, a+b]
+    with ROT to cycle the counter.
+    """
+    if n == 0:
+        return [Instruction(OP_PUSH, 0), Instruction(OP_HALT)], 0
+    if n == 1:
+        return [Instruction(OP_PUSH, 1), Instruction(OP_HALT)], 1
+
+    prog = [
+        Instruction(OP_PUSH, 0),      # 0: a = fib(0)
+        Instruction(OP_PUSH, 1),      # 1: b = fib(1)
+        Instruction(OP_PUSH, n - 1),  # 2: counter = n-1
+        Instruction(OP_ROT),          # 3: [1, n-1, 0]
+        Instruction(OP_ROT),          # 4: [n-1, 0, 1] = [counter, a, b]
+        # ── Loop body (addr 5) ──
+        Instruction(OP_SWAP),         # 5: [counter, b, a]
+        Instruction(OP_OVER),         # 6: [counter, b, a, b]
+        Instruction(OP_ADD),          # 7: [counter, b, a+b]
+        Instruction(OP_ROT),          # 8: [b, a+b, counter]
+        Instruction(OP_PUSH, 1),      # 9
+        Instruction(OP_SUB),          # 10: [b, a+b, counter-1]
+        Instruction(OP_DUP),          # 11: [..., counter-1, counter-1]
+        Instruction(OP_JNZ, 15),      # 12: if counter-1 != 0 -> continue
+        Instruction(OP_POP),          # 13: drop counter=0
+        Instruction(OP_HALT),         # 14: top = fib(n)
+        # ── Continue loop (addr 15) ──
+        Instruction(OP_ROT),          # 15: [new_b, counter-1, new_a]
+        Instruction(OP_ROT),          # 16: [counter-1, new_a, new_b]
+        Instruction(OP_PUSH, 1),      # 17
+        Instruction(OP_JNZ, 5),       # 18: always taken
+    ]
+    return prog, fib(n)
+
+
+def make_power_of_2(n):
+    """Generate a program that computes 2^n via repeated doubling."""
+    if n == 0:
+        return [Instruction(OP_PUSH, 1), Instruction(OP_HALT)], 1
+
+    prog = [
+        Instruction(OP_PUSH, 1),      # 0: value = 1
+        Instruction(OP_PUSH, n),      # 1: counter = n
+        # ── Loop (addr 2) ──
+        Instruction(OP_DUP),          # 2
+        Instruction(OP_JZ, 12),       # 3: if counter == 0 -> done
+        Instruction(OP_PUSH, 1),      # 4
+        Instruction(OP_SUB),          # 5
+        Instruction(OP_SWAP),         # 6
+        Instruction(OP_DUP),          # 7
+        Instruction(OP_ADD),          # 8
+        Instruction(OP_SWAP),         # 9
+        Instruction(OP_PUSH, 1),      # 10
+        Instruction(OP_JNZ, 2),       # 11
+        # ── Done ──
+        Instruction(OP_POP),          # 12
+        Instruction(OP_HALT),         # 13
+    ]
+    prog[3] = Instruction(OP_JZ, 12)
+    return prog, 2 ** n
+
+
+def make_sum_1_to_n(n):
+    """Generate a program that computes 1 + 2 + ... + n."""
+    if n == 0:
+        return [Instruction(OP_PUSH, 0), Instruction(OP_HALT)], 0
+
+    prog = [
+        Instruction(OP_PUSH, 0),      # 0: acc = 0
+        Instruction(OP_PUSH, n),      # 1: counter = n
+        # ── Loop (addr 2) ──
+        Instruction(OP_DUP),          # 2
+        Instruction(OP_JZ, 12),       # 3: if counter == 0 -> done
+        Instruction(OP_DUP),          # 4
+        Instruction(OP_ROT),          # 5
+        Instruction(OP_ADD),          # 6
+        Instruction(OP_SWAP),         # 7
+        Instruction(OP_PUSH, 1),      # 8
+        Instruction(OP_SUB),          # 9
+        Instruction(OP_PUSH, 1),      # 10
+        Instruction(OP_JNZ, 2),       # 11
+        # ── Done (addr 12) ──
+        Instruction(OP_POP),          # 12
+        Instruction(OP_HALT),         # 13
+    ]
+    return prog, n * (n + 1) // 2
+
+
+def make_multiply(a, b):
+    """Generate a program that computes a * b via repeated addition."""
+    if b == 0 or a == 0:
+        return [Instruction(OP_PUSH, 0), Instruction(OP_HALT)], 0
+
+    prog = [
+        Instruction(OP_PUSH, a),      # 0: a
+        Instruction(OP_PUSH, 0),      # 1: result = 0
+        Instruction(OP_PUSH, b),      # 2: counter = b
+        # ── Loop (addr 3) ──
+        Instruction(OP_DUP),          # 3
+        Instruction(OP_JZ, 14),       # 4: if counter == 0 -> done
+        Instruction(OP_PUSH, 1),      # 5
+        Instruction(OP_SUB),          # 6
+        Instruction(OP_ROT),          # 7
+        Instruction(OP_ROT),          # 8
+        Instruction(OP_OVER),         # 9
+        Instruction(OP_ADD),          # 10
+        Instruction(OP_ROT),          # 11
+        Instruction(OP_PUSH, 1),      # 12
+        Instruction(OP_JNZ, 3),       # 13
+        # ── Done (addr 14) ──
+        Instruction(OP_POP),          # 14
+        Instruction(OP_SWAP),         # 15
+        Instruction(OP_POP),          # 16
+        Instruction(OP_HALT),         # 17
+    ]
+    return prog, a * b
+
+
+def make_is_even(n):
+    """Generate a program that returns 1 if n is even, 0 if odd."""
+    prog = [
+        Instruction(OP_PUSH, n),      # 0: n
+        # ── Loop (addr 1) ──
+        Instruction(OP_DUP),          # 1
+        Instruction(OP_JZ, 11),       # 2: if n == 0 -> even
+        Instruction(OP_PUSH, 1),      # 3
+        Instruction(OP_SUB),          # 4
+        Instruction(OP_DUP),          # 5
+        Instruction(OP_JZ, 14),       # 6: if n-1 == 0 -> odd
+        Instruction(OP_PUSH, 1),      # 7
+        Instruction(OP_SUB),          # 8
+        Instruction(OP_PUSH, 1),      # 9
+        Instruction(OP_JNZ, 1),       # 10
+        # ── Even (addr 11) ──
+        Instruction(OP_POP),          # 11
+        Instruction(OP_PUSH, 1),      # 12
+        Instruction(OP_HALT),         # 13
+        # ── Odd (addr 14) ──
+        Instruction(OP_POP),          # 14
+        Instruction(OP_PUSH, 0),      # 15
+        Instruction(OP_HALT),         # 16
+    ]
+    return prog, 1 if n % 2 == 0 else 0
+
+
+# ─── Phase 14 Native-Op Algorithm Generators ─────────────────────
+
+def make_native_multiply(a, b):
+    """Compute a*b using native MUL. 4 instructions."""
+    return [
+        Instruction(OP_PUSH, a),
+        Instruction(OP_PUSH, b),
+        Instruction(OP_MUL),
+        Instruction(OP_HALT),
+    ], a * b
+
+
+def make_native_divmod(a, b):
+    """Compute b/a and b%a. Returns (program, expected_quotient)."""
+    if a == 0:
+        return [
+            Instruction(OP_PUSH, b),
+            Instruction(OP_PUSH, a),
+            Instruction(OP_DIV_S),
+            Instruction(OP_HALT),
+        ], None
+    return [
+        Instruction(OP_PUSH, b),
+        Instruction(OP_PUSH, a),
+        Instruction(OP_DIV_S),
+        Instruction(OP_HALT),
+    ], _trunc_div(b, a)
+
+
+def make_native_remainder(a, b):
+    """Compute b%a using REM_S. Returns (program, expected_remainder)."""
+    if a == 0:
+        return [
+            Instruction(OP_PUSH, b),
+            Instruction(OP_PUSH, a),
+            Instruction(OP_REM_S),
+            Instruction(OP_HALT),
+        ], None
+    return [
+        Instruction(OP_PUSH, b),
+        Instruction(OP_PUSH, a),
+        Instruction(OP_REM_S),
+        Instruction(OP_HALT),
+    ], _trunc_rem(b, a)
+
+
+def make_native_is_even(n):
+    """Test parity using native REM_S + JZ."""
+    prog = [
+        Instruction(OP_PUSH, n),      # 0: n
+        Instruction(OP_PUSH, 2),      # 1: 2
+        Instruction(OP_REM_S),        # 2: n % 2
+        Instruction(OP_JZ, 6),        # 3: if remainder == 0 -> even
+        Instruction(OP_PUSH, 0),      # 4
+        Instruction(OP_HALT),         # 5
+        Instruction(OP_PUSH, 1),      # 6
+        Instruction(OP_HALT),         # 7
+    ]
+    return prog, 1 if n % 2 == 0 else 0
+
+
+def make_factorial(n):
+    """Compute n! using native MUL."""
+    if n <= 1:
+        return [Instruction(OP_PUSH, 1), Instruction(OP_HALT)], 1
+
+    prog = [
+        Instruction(OP_PUSH, 1),      # 0: result = 1
+        Instruction(OP_PUSH, n),      # 1: counter = n
+        # ── Loop (addr 2) ──
+        Instruction(OP_DUP),          # 2
+        Instruction(OP_JZ, 12),       # 3: if counter == 0 -> done
+        Instruction(OP_DUP),          # 4
+        Instruction(OP_ROT),          # 5
+        Instruction(OP_MUL),          # 6
+        Instruction(OP_SWAP),         # 7
+        Instruction(OP_PUSH, 1),      # 8
+        Instruction(OP_SUB),          # 9
+        Instruction(OP_PUSH, 1),      # 10
+        Instruction(OP_JNZ, 2),       # 11
+        # ── Done (addr 12) ──
+        Instruction(OP_POP),          # 12
+        Instruction(OP_HALT),         # 13
+    ]
+    expected = 1
+    for i in range(2, n + 1):
+        expected *= i
+    return prog, expected
+
+
+def make_gcd(a, b):
+    """Compute GCD(a, b) via Euclidean algorithm using native REM_S."""
+    if a == 0 and b == 0:
+        return [Instruction(OP_PUSH, 0), Instruction(OP_HALT)], 0
+
+    prog = [
+        Instruction(OP_PUSH, a),      # 0: a
+        Instruction(OP_PUSH, b),      # 1: b
+        # ── Loop (addr 2) ──
+        Instruction(OP_DUP),          # 2
+        Instruction(OP_JZ, 10),       # 3: if b == 0 -> done
+        Instruction(OP_SWAP),         # 4
+        Instruction(OP_OVER),         # 5
+        Instruction(OP_REM_S),        # 6
+        Instruction(OP_PUSH, 1),      # 7
+        Instruction(OP_JNZ, 2),       # 8
+        Instruction(OP_NOP),          # 9: padding
+        # ── Done (addr 10) ──
+        Instruction(OP_POP),          # 10
+        Instruction(OP_HALT),         # 11
+    ]
+    return prog, math.gcd(a, b)
+
+
+# ─── Comparison Program Generators ──────────────────────────────
+
+def make_compare_eqz(a):
+    """Test a == 0 using EQZ."""
+    return [
+        Instruction(OP_PUSH, a),
+        Instruction(OP_EQZ),
+        Instruction(OP_HALT),
+    ], 1 if a == 0 else 0
+
+
+def make_compare_binary(op, a, b):
+    """Generic binary comparison: PUSH a, PUSH b, OP, HALT."""
+    CMP_SEMANTICS = {
+        OP_EQ:   lambda va, vb: vb == va,
+        OP_NE:   lambda va, vb: vb != va,
+        OP_LT_S: lambda va, vb: vb < va,
+        OP_LT_U: lambda va, vb: vb < va,
+        OP_GT_S: lambda va, vb: vb > va,
+        OP_GT_U: lambda va, vb: vb > va,
+        OP_LE_S: lambda va, vb: vb <= va,
+        OP_LE_U: lambda va, vb: vb <= va,
+        OP_GE_S: lambda va, vb: vb >= va,
+        OP_GE_U: lambda va, vb: vb >= va,
+    }
+    expected = 1 if CMP_SEMANTICS[op](b, a) else 0
+    return [
+        Instruction(OP_PUSH, a),
+        Instruction(OP_PUSH, b),
+        Instruction(op),
+        Instruction(OP_HALT),
+    ], expected
+
+
+def make_native_max(a, b):
+    """Compute max(a, b) using GT_S + JZ."""
+    expected = max(a, b)
+    prog = [
+        Instruction(OP_PUSH, a),      # 0
+        Instruction(OP_PUSH, b),      # 1
+        Instruction(OP_OVER),         # 2
+        Instruction(OP_OVER),         # 3
+        Instruction(OP_GT_S),         # 4
+        Instruction(OP_JZ, 9),        # 5
+        Instruction(OP_POP),          # 6
+        Instruction(OP_HALT),         # 7
+        Instruction(OP_NOP),          # 8
+        Instruction(OP_SWAP),         # 9
+        Instruction(OP_POP),          # 10
+        Instruction(OP_HALT),         # 11
+    ]
+    return prog, expected
+
+
+def make_native_abs(n):
+    """Compute abs(n) using LT_S comparison + conditional negate."""
+    expected = abs(n)
+    prog = [
+        Instruction(OP_PUSH, n),      # 0
+        Instruction(OP_DUP),          # 1
+        Instruction(OP_PUSH, 0),      # 2
+        Instruction(OP_LT_S),         # 3
+        Instruction(OP_JZ, 9),        # 4
+        Instruction(OP_PUSH, 0),      # 5
+        Instruction(OP_SWAP),         # 6
+        Instruction(OP_SUB),          # 7
+        Instruction(OP_HALT),         # 8
+        Instruction(OP_HALT),         # 9
+    ]
+    return prog, expected
+
+
+def make_native_clamp(val, lo, hi):
+    """Clamp val to [lo, hi] using comparisons."""
+    expected = max(lo, min(val, hi))
+    prog = [
+        Instruction(OP_PUSH, val),    # 0
+        Instruction(OP_DUP),          # 1
+        Instruction(OP_PUSH, lo),     # 2
+        Instruction(OP_LT_S),         # 3
+        Instruction(OP_JZ, 8),        # 4
+        Instruction(OP_POP),          # 5
+        Instruction(OP_PUSH, lo),     # 6
+        Instruction(OP_HALT),         # 7
+        Instruction(OP_DUP),          # 8
+        Instruction(OP_PUSH, hi),     # 9
+        Instruction(OP_GT_S),         # 10
+        Instruction(OP_JZ, 15),       # 11
+        Instruction(OP_POP),          # 12
+        Instruction(OP_PUSH, hi),     # 13
+        Instruction(OP_HALT),         # 14
+        Instruction(OP_HALT),         # 15
+    ]
+    return prog, expected
+
+
+# ─── Bitwise Program Generators ─────────────────────────────────
+
+def make_bitwise_binary(op, a, b):
+    """Generic bitwise binary: PUSH a, PUSH b, OP, HALT."""
+    va, vb = b, a
+    BITWISE_SEMANTICS = {
+        OP_AND:   lambda va, vb: _to_i32(va) & _to_i32(vb),
+        OP_OR:    lambda va, vb: _to_i32(va) | _to_i32(vb),
+        OP_XOR:   lambda va, vb: _to_i32(va) ^ _to_i32(vb),
+        OP_SHL:   lambda va, vb: (_to_i32(vb) << (int(va) & 31)) & MASK32,
+        OP_SHR_S: lambda va, vb: _shr_s(vb, va),
+        OP_SHR_U: lambda va, vb: _shr_u(vb, va),
+        OP_ROTL:  lambda va, vb: _rotl32(vb, va),
+        OP_ROTR:  lambda va, vb: _rotr32(vb, va),
+    }
+    expected = BITWISE_SEMANTICS[op](va, vb)
+    return [
+        Instruction(OP_PUSH, a),
+        Instruction(OP_PUSH, b),
+        Instruction(op),
+        Instruction(OP_HALT),
+    ], expected
+
+
+def make_popcount_loop(n):
+    """Count set bits of n using AND + SHR_U loop."""
+    expected = bin(n & MASK32).count('1')
+    prog = [
+        Instruction(OP_PUSH, 0),      # 0: count = 0
+        Instruction(OP_PUSH, n),      # 1: n
+        # ── Loop (addr 2) ──
+        Instruction(OP_DUP),          # 2
+        Instruction(OP_JZ, 14),       # 3: if n == 0 -> done
+        Instruction(OP_DUP),          # 4
+        Instruction(OP_PUSH, 1),      # 5
+        Instruction(OP_AND),          # 6
+        Instruction(OP_ROT),          # 7
+        Instruction(OP_ADD),          # 8
+        Instruction(OP_SWAP),         # 9
+        Instruction(OP_PUSH, 1),      # 10
+        Instruction(OP_SHR_U),        # 11
+        Instruction(OP_PUSH, 1),      # 12
+        Instruction(OP_JNZ, 2),       # 13
+        # ── Done (addr 14) ──
+        Instruction(OP_POP),          # 14
+        Instruction(OP_HALT),         # 15
+    ]
+    return prog, expected
+
+
+def make_bit_extract(n, bit_pos):
+    """Extract bit at position bit_pos from n. Result: 0 or 1."""
+    expected = (_to_i32(n) >> (bit_pos & 31)) & 1
+    prog = [
+        Instruction(OP_PUSH, n),
+        Instruction(OP_PUSH, bit_pos),
+        Instruction(OP_SHR_U),
+        Instruction(OP_PUSH, 1),
+        Instruction(OP_AND),
+        Instruction(OP_HALT),
+    ]
+    return prog, expected
+
+
+# ─── Chunk 4: Unary + Parametric Program Generators ─────────────
+
+def make_native_clz(n):
+    """Count leading zeros of n using native CLZ."""
+    return [
+        Instruction(OP_PUSH, n),
+        Instruction(OP_CLZ),
+        Instruction(OP_HALT),
+    ], _clz32(n)
+
+def make_native_ctz(n):
+    """Count trailing zeros of n using native CTZ."""
+    return [
+        Instruction(OP_PUSH, n),
+        Instruction(OP_CTZ),
+        Instruction(OP_HALT),
+    ], _ctz32(n)
+
+def make_native_popcnt(n):
+    """Population count of n using native POPCNT."""
+    return [
+        Instruction(OP_PUSH, n),
+        Instruction(OP_POPCNT),
+        Instruction(OP_HALT),
+    ], _popcnt32(n)
+
+def make_native_abs_unary(n):
+    """Absolute value using native ABS. 3 instructions."""
+    return [
+        Instruction(OP_PUSH, n),
+        Instruction(OP_ABS),
+        Instruction(OP_HALT),
+    ], abs(int(n))
+
+def make_native_neg(n):
+    """Negate n using native NEG."""
+    return [
+        Instruction(OP_PUSH, n),
+        Instruction(OP_NEG),
+        Instruction(OP_HALT),
+    ], -int(n)
+
+def make_select(a, b, c):
+    """SELECT: push a, b, c; SELECT pops all three -> (c!=0 ? a : b)."""
+    expected = a if c != 0 else b
+    return [
+        Instruction(OP_PUSH, a),
+        Instruction(OP_PUSH, b),
+        Instruction(OP_PUSH, c),
+        Instruction(OP_SELECT),
+        Instruction(OP_HALT),
+    ], expected
+
+def make_select_max(a, b):
+    """Max of two numbers using GT_S + SELECT."""
+    expected = max(a, b)
+    prog = [
+        Instruction(OP_PUSH, a),   # 0
+        Instruction(OP_PUSH, b),   # 1
+        Instruction(OP_PUSH, a),   # 2
+        Instruction(OP_PUSH, b),   # 3
+        Instruction(OP_GT_S),      # 4
+        Instruction(OP_SELECT),    # 5
+        Instruction(OP_HALT),      # 6
+    ]
+    return prog, expected
+
+def make_log2_floor(n):
+    """Floor of log2(n) using CLZ: 31 - CLZ(n)."""
+    if n <= 0:
+        return [Instruction(OP_PUSH, 0), Instruction(OP_HALT)], 0
+    expected = 31 - _clz32(n)
+    prog = [
+        Instruction(OP_PUSH, n),
+        Instruction(OP_CLZ),
+        Instruction(OP_PUSH, 31),
+        Instruction(OP_SWAP),
+        Instruction(OP_SUB),
+        Instruction(OP_HALT),
+    ]
+    return prog, expected
+
+def make_is_power_of_2(n):
+    """Check if n is a power of 2 using POPCNT."""
+    expected = 1 if (n > 0 and _popcnt32(n) == 1) else 0
+    prog = [
+        Instruction(OP_PUSH, n),
+        Instruction(OP_POPCNT),
+        Instruction(OP_PUSH, 1),
+        Instruction(OP_EQ),
+        Instruction(OP_HALT),
+    ]
+    return prog, expected

--- a/test_consolidated.py
+++ b/test_consolidated.py
@@ -1,0 +1,468 @@
+"""Equivalence tests: verify consolidated modules match phase14 behavior exactly.
+
+Imports ONLY from the new modules (isa, executor, programs).
+Cross-validates against old Phase14Executor and Phase14PyTorchExecutor.
+"""
+
+import sys
+import os
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from isa import (
+    Instruction, compare_traces, test_algorithm, test_trap_algorithm,
+    OP_PUSH, OP_POP, OP_ADD, OP_DUP, OP_HALT,
+    OP_SUB, OP_JZ, OP_JNZ, OP_NOP,
+    OP_SWAP, OP_OVER, OP_ROT,
+    OP_MUL, OP_DIV_S, OP_DIV_U, OP_REM_S, OP_REM_U,
+    OP_EQZ, OP_EQ, OP_NE,
+    OP_LT_S, OP_LT_U, OP_GT_S, OP_GT_U,
+    OP_LE_S, OP_LE_U, OP_GE_S, OP_GE_U,
+    OP_AND, OP_OR, OP_XOR,
+    OP_SHL, OP_SHR_S, OP_SHR_U, OP_ROTL, OP_ROTR,
+    OP_CLZ, OP_CTZ, OP_POPCNT, OP_ABS, OP_NEG, OP_SELECT,
+    OP_TRAP,
+)
+from executor import NumPyExecutor, TorchExecutor
+from programs import (
+    ALL_TESTS,
+    make_fibonacci, make_power_of_2, make_sum_1_to_n, make_multiply, make_is_even,
+    make_native_multiply, make_native_divmod, make_native_remainder,
+    make_native_is_even, make_factorial, make_gcd,
+    make_compare_eqz, make_compare_binary,
+    make_native_max, make_native_abs, make_native_clamp,
+    make_bitwise_binary, make_popcount_loop, make_bit_extract,
+    make_native_clz, make_native_ctz, make_native_popcnt,
+    make_native_abs_unary, make_native_neg,
+    make_select, make_select_max, make_log2_floor, make_is_power_of_2,
+    fib,
+)
+
+# Cross-validation imports from old phase files
+from phase14_extended_isa import (
+    Phase14Executor, Phase14PyTorchExecutor,
+)
+
+
+def test_numpy_equivalence():
+    """Verify NumPyExecutor matches Phase14Executor on all programs."""
+    print("=" * 60)
+    print("Test 1: NumPy Executor Equivalence")
+    print("=" * 60)
+
+    old = Phase14Executor()
+    new = NumPyExecutor()
+
+    passed = 0
+    total = 0
+
+    # Phase 4 tests
+    for name, test_fn in ALL_TESTS:
+        prog, expected_top = test_fn()
+        old_trace = old.execute(prog)
+        new_trace = new.execute(prog)
+        match, detail = compare_traces(old_trace, new_trace)
+        old_top = old_trace.steps[-1].top if old_trace.steps else None
+        new_top = new_trace.steps[-1].top if new_trace.steps else None
+        ok = match and old_top == expected_top and new_top == expected_top
+        if ok: passed += 1
+        total += 1
+        status = "PASS" if ok else "FAIL"
+        print(f"  {status}  {name:25s}  expected={expected_top:>6}  old={old_top}  new={new_top}  match={'Y' if match else 'N'}")
+        if not ok and not match:
+            print(f"         Detail: {detail}")
+
+    # Phase 11 extended tests
+    ext_tests = [
+        ("sub_basic",
+         [Instruction(OP_PUSH, 10), Instruction(OP_PUSH, 3),
+          Instruction(OP_SUB), Instruction(OP_HALT)], 7),
+        ("loop_countdown",
+         [Instruction(OP_PUSH, 3), Instruction(OP_DUP),
+          Instruction(OP_PUSH, 1), Instruction(OP_SUB),
+          Instruction(OP_DUP), Instruction(OP_JNZ, 1),
+          Instruction(OP_HALT)], 0),
+        ("jz_taken",
+         [Instruction(OP_PUSH, 0), Instruction(OP_JZ, 3),
+          Instruction(OP_HALT),
+          Instruction(OP_PUSH, 42), Instruction(OP_HALT)], 42),
+    ]
+    for name, prog, expected in ext_tests:
+        old_trace = old.execute(prog)
+        new_trace = new.execute(prog)
+        match, detail = compare_traces(old_trace, new_trace)
+        old_top = old_trace.steps[-1].top if old_trace.steps else None
+        new_top = new_trace.steps[-1].top if new_trace.steps else None
+        ok = match and old_top == expected and new_top == expected
+        if ok: passed += 1
+        total += 1
+        status = "PASS" if ok else "FAIL"
+        print(f"  {status}  {name:25s}  expected={expected:>6}  old={old_top}  new={new_top}  match={'Y' if match else 'N'}")
+
+    # Phase 13 algorithms
+    p13_algos = [
+        ("fib(10)", *make_fibonacci(10)),
+        ("fib(7)", *make_fibonacci(7)),
+        ("sum(1..10)", *make_sum_1_to_n(10)),
+        ("power(2^5)", *make_power_of_2(5)),
+        ("mul(7,8)", *make_multiply(7, 8)),
+        ("is_even(10)", *make_is_even(10)),
+        ("is_even(7)", *make_is_even(7)),
+    ]
+    for name, prog, expected in p13_algos:
+        old_trace = old.execute(prog)
+        new_trace = new.execute(prog)
+        match, detail = compare_traces(old_trace, new_trace)
+        old_top = old_trace.steps[-1].top if old_trace.steps else None
+        new_top = new_trace.steps[-1].top if new_trace.steps else None
+        ok = match and old_top == expected and new_top == expected
+        if ok: passed += 1
+        total += 1
+        status = "PASS" if ok else "FAIL"
+        print(f"  {status}  {name:25s}  expected={expected:>6}  old={old_top}  new={new_top}  match={'Y' if match else 'N'}")
+
+    # Phase 14 arithmetic
+    arith_tests = [
+        ("native_mul(7,8)", *make_native_multiply(7, 8)),
+        ("native_mul(0,5)", *make_native_multiply(0, 5)),
+        ("native_divmod(3,10)", *make_native_divmod(3, 10)),
+        ("native_rem(3,10)", *make_native_remainder(3, 10)),
+        ("factorial(5)", *make_factorial(5)),
+        ("factorial(10)", *make_factorial(10)),
+        ("gcd(12,8)", *make_gcd(12, 8)),
+        ("gcd(100,75)", *make_gcd(100, 75)),
+        ("native_is_even(42)", *make_native_is_even(42)),
+        ("native_is_even(15)", *make_native_is_even(15)),
+    ]
+    for name, prog, expected in arith_tests:
+        old_trace = old.execute(prog)
+        new_trace = new.execute(prog)
+        match, detail = compare_traces(old_trace, new_trace)
+        old_top = old_trace.steps[-1].top if old_trace.steps else None
+        new_top = new_trace.steps[-1].top if new_trace.steps else None
+        ok = match and old_top == expected and new_top == expected
+        if ok: passed += 1
+        total += 1
+        status = "PASS" if ok else "FAIL"
+        print(f"  {status}  {name:25s}  expected={expected:>6}  old={old_top}  new={new_top}  match={'Y' if match else 'N'}")
+
+    # Phase 14 comparisons
+    cmp_tests = [
+        ("eqz(0)", *make_compare_eqz(0)),
+        ("eqz(5)", *make_compare_eqz(5)),
+        ("eq(5,5)", *make_compare_binary(OP_EQ, 5, 5)),
+        ("lt_s(3,7)", *make_compare_binary(OP_LT_S, 3, 7)),
+        ("gt_s(10,2)", *make_compare_binary(OP_GT_S, 10, 2)),
+        ("max(3,7)", *make_native_max(3, 7)),
+        ("max(10,2)", *make_native_max(10, 2)),
+        ("abs(42)", *make_native_abs(42)),
+        ("clamp(5,0,10)", *make_native_clamp(5, 0, 10)),
+        ("clamp(15,0,10)", *make_native_clamp(15, 0, 10)),
+    ]
+    for name, prog, expected in cmp_tests:
+        old_trace = old.execute(prog)
+        new_trace = new.execute(prog)
+        match, detail = compare_traces(old_trace, new_trace)
+        old_top = old_trace.steps[-1].top if old_trace.steps else None
+        new_top = new_trace.steps[-1].top if new_trace.steps else None
+        ok = match and old_top == expected and new_top == expected
+        if ok: passed += 1
+        total += 1
+        status = "PASS" if ok else "FAIL"
+        print(f"  {status}  {name:25s}  expected={expected:>6}  old={old_top}  new={new_top}  match={'Y' if match else 'N'}")
+
+    # Phase 14 bitwise
+    bit_tests = [
+        ("and(0xFF,0x0F)", *make_bitwise_binary(OP_AND, 0xFF, 0x0F)),
+        ("or(0xF0,0x0F)", *make_bitwise_binary(OP_OR, 0xF0, 0x0F)),
+        ("xor(0xFF,0xFF)", *make_bitwise_binary(OP_XOR, 0xFF, 0xFF)),
+        ("shl(1,4)", *make_bitwise_binary(OP_SHL, 1, 4)),
+        ("shr_u(16,1)", *make_bitwise_binary(OP_SHR_U, 16, 1)),
+        ("rotl(1,1)", *make_bitwise_binary(OP_ROTL, 1, 1)),
+        ("rotr(2,1)", *make_bitwise_binary(OP_ROTR, 2, 1)),
+        ("popcount(255)", *make_popcount_loop(255)),
+        ("bit(0xFF,4)", *make_bit_extract(0xFF, 4)),
+    ]
+    for name, prog, expected in bit_tests:
+        old_trace = old.execute(prog)
+        new_trace = new.execute(prog)
+        match, detail = compare_traces(old_trace, new_trace)
+        old_top = old_trace.steps[-1].top if old_trace.steps else None
+        new_top = new_trace.steps[-1].top if new_trace.steps else None
+        ok = match and old_top == expected and new_top == expected
+        if ok: passed += 1
+        total += 1
+        status = "PASS" if ok else "FAIL"
+        print(f"  {status}  {name:25s}  expected={expected:>6}  old={old_top}  new={new_top}  match={'Y' if match else 'N'}")
+
+    # Phase 14 unary + parametric
+    unary_tests = [
+        ("clz(0)", *make_native_clz(0)),
+        ("clz(255)", *make_native_clz(255)),
+        ("ctz(8)", *make_native_ctz(8)),
+        ("popcnt(255)", *make_native_popcnt(255)),
+        ("abs_native(42)", *make_native_abs_unary(42)),
+        ("abs_native(-7)", *make_native_abs_unary(-7)),
+        ("neg(5)", *make_native_neg(5)),
+        ("neg(-3)", *make_native_neg(-3)),
+        ("select(10,20,1)", *make_select(10, 20, 1)),
+        ("select(10,20,0)", *make_select(10, 20, 0)),
+        ("select_max(10,25)", *make_select_max(10, 25)),
+        ("log2(8)", *make_log2_floor(8)),
+        ("ispow2(8)", *make_is_power_of_2(8)),
+        ("ispow2(7)", *make_is_power_of_2(7)),
+    ]
+    for name, prog, expected in unary_tests:
+        old_trace = old.execute(prog)
+        new_trace = new.execute(prog)
+        match, detail = compare_traces(old_trace, new_trace)
+        old_top = old_trace.steps[-1].top if old_trace.steps else None
+        new_top = new_trace.steps[-1].top if new_trace.steps else None
+        ok = match and old_top == expected and new_top == expected
+        if ok: passed += 1
+        total += 1
+        status = "PASS" if ok else "FAIL"
+        print(f"  {status}  {name:25s}  expected={expected:>6}  old={old_top}  new={new_top}  match={'Y' if match else 'N'}")
+
+    # Division by zero traps
+    trap_progs = [
+        ("div_by_zero",
+         [Instruction(OP_PUSH, 10), Instruction(OP_PUSH, 0),
+          Instruction(OP_DIV_S), Instruction(OP_HALT)]),
+        ("rem_by_zero",
+         [Instruction(OP_PUSH, 10), Instruction(OP_PUSH, 0),
+          Instruction(OP_REM_S), Instruction(OP_HALT)]),
+    ]
+    for name, prog in trap_progs:
+        old_trace = old.execute(prog)
+        new_trace = new.execute(prog)
+        match, detail = compare_traces(old_trace, new_trace)
+        old_trapped = old_trace.steps and old_trace.steps[-1].op == OP_TRAP
+        new_trapped = new_trace.steps and new_trace.steps[-1].op == OP_TRAP
+        ok = match and old_trapped and new_trapped
+        if ok: passed += 1
+        total += 1
+        status = "PASS" if ok else "FAIL"
+        print(f"  {status}  {name:25s}  old_trap={old_trapped}  new_trap={new_trapped}  match={'Y' if match else 'N'}")
+
+    print(f"\n  NumPy equivalence: {passed}/{total} passed")
+    return passed == total
+
+
+def test_torch_equivalence():
+    """Verify TorchExecutor matches Phase14PyTorchExecutor on all programs."""
+    print("\n" + "=" * 60)
+    print("Test 2: Torch Executor Equivalence")
+    print("=" * 60)
+
+    old = Phase14PyTorchExecutor()
+    new = TorchExecutor()
+
+    passed = 0
+    total = 0
+
+    # Phase 4 tests
+    for name, test_fn in ALL_TESTS:
+        prog, expected_top = test_fn()
+        old_trace = old.execute(prog)
+        new_trace = new.execute(prog)
+        match, detail = compare_traces(old_trace, new_trace)
+        old_top = old_trace.steps[-1].top if old_trace.steps else None
+        new_top = new_trace.steps[-1].top if new_trace.steps else None
+        ok = match and old_top == expected_top and new_top == expected_top
+        if ok: passed += 1
+        total += 1
+        status = "PASS" if ok else "FAIL"
+        print(f"  {status}  {name:25s}  expected={expected_top:>6}  old={old_top}  new={new_top}  match={'Y' if match else 'N'}")
+        if not ok and not match:
+            print(f"         Detail: {detail}")
+
+    # Phase 13 algorithms
+    p13_algos = [
+        ("fib(10)", *make_fibonacci(10)),
+        ("sum(1..10)", *make_sum_1_to_n(10)),
+        ("power(2^5)", *make_power_of_2(5)),
+        ("mul(7,8)", *make_multiply(7, 8)),
+    ]
+    for name, prog, expected in p13_algos:
+        old_trace = old.execute(prog)
+        new_trace = new.execute(prog)
+        match, detail = compare_traces(old_trace, new_trace)
+        old_top = old_trace.steps[-1].top if old_trace.steps else None
+        new_top = new_trace.steps[-1].top if new_trace.steps else None
+        ok = match and old_top == expected and new_top == expected
+        if ok: passed += 1
+        total += 1
+        status = "PASS" if ok else "FAIL"
+        print(f"  {status}  {name:25s}  expected={expected:>6}  old={old_top}  new={new_top}  match={'Y' if match else 'N'}")
+
+    # Phase 14 arithmetic + comparison + bitwise + unary
+    p14_tests = [
+        ("native_mul(12,10)", *make_native_multiply(12, 10)),
+        ("factorial(7)", *make_factorial(7)),
+        ("gcd(48,36)", *make_gcd(48, 36)),
+        ("eqz(0)", *make_compare_eqz(0)),
+        ("gt_s(10,2)", *make_compare_binary(OP_GT_S, 10, 2)),
+        ("max(10,25)", *make_native_max(10, 25)),
+        ("and(0xAA,0x55)", *make_bitwise_binary(OP_AND, 0xAA, 0x55)),
+        ("popcount(15)", *make_popcount_loop(15)),
+        ("clz(1)", *make_native_clz(1)),
+        ("popcnt_native(7)", *make_native_popcnt(7)),
+        ("abs_native(-7)", *make_native_abs_unary(-7)),
+        ("neg(5)", *make_native_neg(5)),
+        ("select(10,20,1)", *make_select(10, 20, 1)),
+        ("select_max(25,10)", *make_select_max(25, 10)),
+        ("log2(1024)", *make_log2_floor(1024)),
+        ("ispow2(1024)", *make_is_power_of_2(1024)),
+    ]
+    for name, prog, expected in p14_tests:
+        old_trace = old.execute(prog)
+        new_trace = new.execute(prog)
+        match, detail = compare_traces(old_trace, new_trace)
+        old_top = old_trace.steps[-1].top if old_trace.steps else None
+        new_top = new_trace.steps[-1].top if new_trace.steps else None
+        ok = match and old_top == expected and new_top == expected
+        if ok: passed += 1
+        total += 1
+        status = "PASS" if ok else "FAIL"
+        print(f"  {status}  {name:25s}  expected={expected:>6}  old={old_top}  new={new_top}  match={'Y' if match else 'N'}")
+
+    # Trap tests
+    trap_progs = [
+        ("div_by_zero",
+         [Instruction(OP_PUSH, 10), Instruction(OP_PUSH, 0),
+          Instruction(OP_DIV_S), Instruction(OP_HALT)]),
+        ("rem_by_zero",
+         [Instruction(OP_PUSH, 10), Instruction(OP_PUSH, 0),
+          Instruction(OP_REM_U), Instruction(OP_HALT)]),
+    ]
+    for name, prog in trap_progs:
+        old_trace = old.execute(prog)
+        new_trace = new.execute(prog)
+        match, detail = compare_traces(old_trace, new_trace)
+        old_trapped = old_trace.steps and old_trace.steps[-1].op == OP_TRAP
+        new_trapped = new_trace.steps and new_trace.steps[-1].op == OP_TRAP
+        ok = match and old_trapped and new_trapped
+        if ok: passed += 1
+        total += 1
+        status = "PASS" if ok else "FAIL"
+        print(f"  {status}  {name:25s}  old_trap={old_trapped}  new_trap={new_trapped}  match={'Y' if match else 'N'}")
+
+    print(f"\n  Torch equivalence: {passed}/{total} passed")
+    return passed == total
+
+
+def test_new_np_vs_new_pt():
+    """Verify new NumPyExecutor matches new TorchExecutor (internal consistency)."""
+    print("\n" + "=" * 60)
+    print("Test 3: New NumPy vs New Torch (Internal Consistency)")
+    print("=" * 60)
+
+    np_exec = NumPyExecutor()
+    pt_exec = TorchExecutor()
+
+    passed = 0
+    total = 0
+
+    all_progs = []
+
+    # Phase 4
+    for name, test_fn in ALL_TESTS:
+        prog, expected = test_fn()
+        all_progs.append((name, prog, expected))
+
+    # Phase 13 algorithms
+    all_progs.extend([
+        ("fib(10)", *make_fibonacci(10)),
+        ("sum(1..15)", *make_sum_1_to_n(15)),
+        ("power(2^7)", *make_power_of_2(7)),
+        ("mul(12,10)", *make_multiply(12, 10)),
+    ])
+
+    # Phase 14 full coverage
+    all_progs.extend([
+        ("native_mul(100,200)", *make_native_multiply(100, 200)),
+        ("factorial(10)", *make_factorial(10)),
+        ("gcd(17,13)", *make_gcd(17, 13)),
+        ("native_is_even(100)", *make_native_is_even(100)),
+        ("eq(5,5)", *make_compare_binary(OP_EQ, 5, 5)),
+        ("ne(3,7)", *make_compare_binary(OP_NE, 3, 7)),
+        ("le_s(3,7)", *make_compare_binary(OP_LE_S, 3, 7)),
+        ("ge_s(10,2)", *make_compare_binary(OP_GE_S, 10, 2)),
+        ("max(5,5)", *make_native_max(5, 5)),
+        ("clamp(0,5,10)", *make_native_clamp(0, 5, 10)),
+        ("or(0xAA,0x55)", *make_bitwise_binary(OP_OR, 0xAA, 0x55)),
+        ("xor(12,10)", *make_bitwise_binary(OP_XOR, 12, 10)),
+        ("shl(0xFF,4)", *make_bitwise_binary(OP_SHL, 0xFF, 4)),
+        ("shr_s(16,1)", *make_bitwise_binary(OP_SHR_S, 16, 1)),
+        ("popcount(0xFFFF)", *make_popcount_loop(0xFFFF)),
+        ("bit(42,3)", *make_bit_extract(42, 3)),
+        ("clz(65536)", *make_native_clz(65536)),
+        ("ctz(1024)", *make_native_ctz(1024)),
+        ("popcnt_native(1023)", *make_native_popcnt(1023)),
+        ("abs_native(0)", *make_native_abs_unary(0)),
+        ("neg(1000)", *make_native_neg(1000)),
+        ("select(5,9,-1)", *make_select(5, 9, -1)),
+        ("select_max(7,7)", *make_select_max(7, 7)),
+        ("log2(255)", *make_log2_floor(255)),
+        ("ispow2(0)", *make_is_power_of_2(0)),
+    ])
+
+    for name, prog, expected in all_progs:
+        np_trace = np_exec.execute(prog)
+        pt_trace = pt_exec.execute(prog)
+        match, detail = compare_traces(np_trace, pt_trace)
+        np_top = np_trace.steps[-1].top if np_trace.steps else None
+        pt_top = pt_trace.steps[-1].top if pt_trace.steps else None
+        ok = match and np_top == expected and pt_top == expected
+        if ok: passed += 1
+        total += 1
+        status = "PASS" if ok else "FAIL"
+        print(f"  {status}  {name:25s}  expected={expected:>10}  np={np_top}  pt={pt_top}  match={'Y' if match else 'N'}")
+        if not ok:
+            if not match:
+                print(f"         Detail: {detail}")
+
+    print(f"\n  Internal consistency: {passed}/{total} passed")
+    return passed == total
+
+
+def main():
+    print("=" * 60)
+    print("Consolidated Module Equivalence Tests")
+    print("=" * 60)
+    print()
+
+    t0 = time.time()
+
+    results = []
+    results.append(("NumPy equivalence", test_numpy_equivalence()))
+    results.append(("Torch equivalence", test_torch_equivalence()))
+    results.append(("Internal consistency", test_new_np_vs_new_pt()))
+
+    elapsed = time.time() - t0
+
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+
+    all_pass = True
+    for name, ok in results:
+        status = "PASS" if ok else "FAIL"
+        if not ok: all_pass = False
+        print(f"  {status}  {name}")
+
+    print(f"\n  Time: {elapsed:.2f}s")
+
+    if all_pass:
+        print("\n  All tests pass. Consolidated modules are equivalent to phase files.")
+    else:
+        print("\n  FAILURES detected. See details above.")
+
+    return all_pass
+
+
+if __name__ == "__main__":
+    ok = main()
+    sys.exit(0 if ok else 1)


### PR DESCRIPTION
## Summary

- Extract 3 flat consolidated files (`isa.py`, `executor.py`, `programs.py`) representing the final state of the 42-opcode Tier 1 ISA, replacing the 5-file inheritance chain (phase4→phase11→phase12→phase13→phase14, ~7000 lines)
- Flatten all executor classes — no `super()` calls, no inheritance, readable top-to-bottom
- Add `test_consolidated.py` with 136 equivalence tests verifying trace-level match between old phase14 executors and new consolidated executors on both NumPy and PyTorch backends
- Phase files remain completely untouched (research history)

## New files

| File | Lines | Contents |
|------|-------|----------|
| `isa.py` | ~370 | Types, constants, 42 opcodes, dimension layout, math helpers, `CompiledAttentionHead`, embedding functions, test utilities |
| `executor.py` | ~430 | `NumPyExecutor`, `CompiledModel` (nn.Module), `TorchExecutor` — all flattened |
| `programs.py` | ~400 | All program generators from phase4/13/14 + `ALL_TESTS` regression list |
| `test_consolidated.py` | ~350 | Cross-validation: old vs new executors, 136/136 tests passing |

## Test plan

- [x] `python test_consolidated.py` — 136/136 pass (NumPy equivalence, Torch equivalence, internal consistency)
- [x] `python phase14_extended_isa.py` — all existing tests still pass (phase files unmodified)
- [ ] Verify phase15+ can import from `isa.py` + `executor.py` instead of phase14

Closes #28

https://claude.ai/code/session_01UTmFUWtej6UnFM7nAF4C99