### PR TITLE
Add TokenVocab with compiled embedding/unembedding tables

### DIFF
--- a/_MAP.md
+++ b/_MAP.md
@@ -90,18 +90,25 @@
 ### isa.py
 > Imports: `torch, typing, dataclasses`
 - **program** (f) `(*instrs)` :37
-- **CompiledAttentionHead** (C) :430
-  - **__init__** (m) `(self, d_model=D_MODEL, head_dim=2, v_dim=1, use_bias_q=False)` :444
-  - **forward** (m) `(self, query_emb, memory_embs)` :451
-- **embed_program_token** (f) `(pos, instr)` :479
-- **embed_stack_entry** (f) `(addr, value, write_order)` :494
-- **embed_local_entry** (f) `(local_idx, value, write_order)` :505
-- **embed_heap_entry** (f) `(addr, value, write_order)` :516
-- **embed_call_frame** (f) `(depth, ret_addr, saved_sp, locals_base, write_order)` :527
-- **embed_state** (f) `(ip, sp)` :540
-- **compare_traces** (f) `(trace_a, trace_b)` :552
-- **test_algorithm** (f) `(name, prog, expected, np_exec, pt_exec, verbose=False)` :562
-- **test_trap_algorithm** (f) `(name, prog, np_exec, pt_exec, verbose=False)` :591
+- **TokenVocab** (C) :430
+  - **encode** (m) `(self, token)` :506
+  - **decode** (m) `(self, tid)` :548
+  - **compile_embedding** (m) `(self, d_model=None)` :572
+  - **compile_unembedding** (m) `(self, embedding=None, d_model=None)` :628
+  - **opcode_name** (m) `(self, op_code)` :658
+  - **token_name** (m) `(self, tid)` :662
+- **CompiledAttentionHead** (C) :684
+  - **__init__** (m) `(self, d_model=D_MODEL, head_dim=2, v_dim=1, use_bias_q=False)` :698
+  - **forward** (m) `(self, query_emb, memory_embs)` :705
+- **embed_program_token** (f) `(pos, instr)` :733
+- **embed_stack_entry** (f) `(addr, value, write_order)` :748
+- **embed_local_entry** (f) `(local_idx, value, write_order)` :759
+- **embed_heap_entry** (f) `(addr, value, write_order)` :770
+- **embed_call_frame** (f) `(depth, ret_addr, saved_sp, locals_base, write_order)` :781
+- **embed_state** (f) `(ip, sp)` :794
+- **compare_traces** (f) `(trace_a, trace_b)` :806
+- **test_algorithm** (f) `(name, prog, expected, np_exec, pt_exec, verbose=False)` :816
+- **test_trap_algorithm** (f) `(name, prog, np_exec, pt_exec, verbose=False)` :845
 
 ### phase10_digit_decomposition.py
 > Imports: `torch, torch.utils.data, random, time, json`...

--- a/isa.py
+++ b/isa.py
@@ -425,6 +425,260 @@ def _sign_extend_16(val):
     return v - 0x10000 if v >= 0x8000 else v
 
 
+# ─── Token Vocabulary and Embedding Tables ────────────────────────
+
+class TokenVocab:
+    """Fixed token vocabulary for the compiled transformer.
+
+    Covers all token types that appear in execution traces:
+      - Special tokens: PAD, COMMIT, BRANCH_TAKEN, BRANCH_NOT_TAKEN
+      - Opcodes: 55 ISA opcodes + TRAP (56 tokens)
+      - Byte values: integers 0-255 (256 tokens)
+      - SP deltas: -3 to +3 (7 tokens)
+
+    Provides encode(token) -> int and decode(int) -> token,
+    plus compiled nn.Embedding and nn.Linear (unembedding) tables.
+    """
+
+    # --- Token type tags (used in encode/decode) ---
+    OPCODE = "op"
+    VALUE  = "val"
+    SP_DELTA = "sp_delta"
+    SPECIAL = "special"
+
+    # --- Special token names ---
+    PAD = "PAD"
+    COMMIT = "COMMIT"
+    BRANCH_TAKEN = "BRANCH_TAKEN"
+    BRANCH_NOT_TAKEN = "BRANCH_NOT_TAKEN"
+
+    # --- Layout: reserved ranges ---
+    _SPECIAL_BASE = 0
+    _SPECIAL_COUNT = 4
+    _OPCODE_BASE = _SPECIAL_BASE + _SPECIAL_COUNT       # 4
+    _OPCODE_COUNT = N_OPCODES + 1                        # 55 opcodes + TRAP = 56
+    _VALUE_BASE = _OPCODE_BASE + _OPCODE_COUNT           # 60
+    _VALUE_COUNT = 256                                    # byte values 0-255
+    _SP_DELTA_BASE = _VALUE_BASE + _VALUE_COUNT           # 316
+    _SP_DELTA_MIN = -3
+    _SP_DELTA_MAX = 3
+    _SP_DELTA_COUNT = _SP_DELTA_MAX - _SP_DELTA_MIN + 1  # 7
+
+    VOCAB_SIZE = _SP_DELTA_BASE + _SP_DELTA_COUNT         # 323
+
+    # --- Special token IDs ---
+    PAD_ID = 0
+    COMMIT_ID = 1
+    BRANCH_TAKEN_ID = 2
+    BRANCH_NOT_TAKEN_ID = 3
+
+    _SPECIAL_NAMES = {
+        PAD_ID: PAD,
+        COMMIT_ID: COMMIT,
+        BRANCH_TAKEN_ID: BRANCH_TAKEN,
+        BRANCH_NOT_TAKEN_ID: BRANCH_NOT_TAKEN,
+    }
+    _SPECIAL_IDS = {v: k for k, v in _SPECIAL_NAMES.items()}
+
+    # --- Opcode <-> token ID mapping ---
+    # OP codes are 1-55 (contiguous) + 99 (TRAP).
+    # Map them to sequential slots starting at _OPCODE_BASE.
+    _OPCODE_TO_SLOT = {}  # built in __init_subclass__ / class body
+    _SLOT_TO_OPCODE = {}
+
+    def __init__(self):
+        # Build opcode mappings from the canonical OPCODE_IDX map
+        self._opcode_to_tid = {}
+        self._tid_to_opcode = {}
+        for op_code, idx in OPCODE_IDX.items():
+            tid = self._OPCODE_BASE + idx
+            self._opcode_to_tid[op_code] = tid
+            self._tid_to_opcode[tid] = op_code
+        # TRAP gets the last opcode slot
+        trap_tid = self._OPCODE_BASE + N_OPCODES  # slot 59
+        self._opcode_to_tid[OP_TRAP] = trap_tid
+        self._tid_to_opcode[trap_tid] = OP_TRAP
+
+        self.vocab_size = self.VOCAB_SIZE
+
+    # ---- encode / decode ----
+
+    def encode(self, token):
+        """Encode a token to its vocabulary ID.
+
+        Args:
+            token: one of:
+              - ("op", opcode_int)       e.g. ("op", 1) for PUSH
+              - ("val", int_0_to_255)    e.g. ("val", 42)
+              - ("sp_delta", int)        e.g. ("sp_delta", -1)
+              - ("special", name_str)    e.g. ("special", "COMMIT")
+              - str for special names    e.g. "PAD", "COMMIT"
+
+        Returns:
+            int: token ID in [0, vocab_size)
+        """
+        if isinstance(token, str):
+            # Shorthand: bare string = special token
+            if token in self._SPECIAL_IDS:
+                return self._SPECIAL_IDS[token]
+            raise ValueError(f"Unknown special token: {token!r}")
+
+        tag, val = token
+        if tag == self.OPCODE:
+            if val not in self._opcode_to_tid:
+                raise ValueError(f"Unknown opcode: {val}")
+            return self._opcode_to_tid[val]
+        elif tag == self.VALUE:
+            if not (0 <= val <= 255):
+                raise ValueError(f"Value out of byte range: {val}")
+            return self._VALUE_BASE + val
+        elif tag == self.SP_DELTA:
+            if not (self._SP_DELTA_MIN <= val <= self._SP_DELTA_MAX):
+                raise ValueError(
+                    f"SP delta {val} out of range [{self._SP_DELTA_MIN}, {self._SP_DELTA_MAX}]"
+                )
+            return self._SP_DELTA_BASE + (val - self._SP_DELTA_MIN)
+        elif tag == self.SPECIAL:
+            if val in self._SPECIAL_IDS:
+                return self._SPECIAL_IDS[val]
+            raise ValueError(f"Unknown special token: {val!r}")
+        else:
+            raise ValueError(f"Unknown token tag: {tag!r}")
+
+    def decode(self, tid):
+        """Decode a token ID back to its structured representation.
+
+        Returns:
+            tuple: (tag, value) — e.g. ("op", 1), ("val", 42), ("special", "PAD")
+        """
+        if not (0 <= tid < self.vocab_size):
+            raise ValueError(f"Token ID {tid} out of range [0, {self.vocab_size})")
+
+        if tid < self._OPCODE_BASE:
+            # Special token
+            return (self.SPECIAL, self._SPECIAL_NAMES[tid])
+        elif tid < self._VALUE_BASE:
+            # Opcode
+            return (self.OPCODE, self._tid_to_opcode[tid])
+        elif tid < self._SP_DELTA_BASE:
+            # Byte value
+            return (self.VALUE, tid - self._VALUE_BASE)
+        else:
+            # SP delta
+            return (self.SP_DELTA, (tid - self._SP_DELTA_BASE) + self._SP_DELTA_MIN)
+
+    # ---- Compiled embedding / unembedding ----
+
+    def compile_embedding(self, d_model=None):
+        """Build nn.Embedding with analytically set weights.
+
+        Each token's embedding row is set so that:
+          - Opcode tokens: DIM_OPCODE = opcode_int, DIM_IS_* = 1.0, DIM_ONE = 1.0
+          - Value tokens: DIM_VALUE = value_int, DIM_ONE = 1.0
+          - SP delta tokens: DIM_SP = delta_int, DIM_ONE = 1.0
+          - Special tokens: DIM_ONE = 1.0 (PAD is all zeros)
+
+        Returns:
+            nn.Embedding with shape (vocab_size, d_model), weights frozen.
+        """
+        if d_model is None:
+            d_model = D_MODEL
+        emb = nn.Embedding(self.vocab_size, d_model)
+        W = torch.zeros(self.vocab_size, d_model, dtype=DTYPE)
+
+        # Special tokens
+        # PAD: all zeros (row 0 stays zero)
+        # COMMIT: unique signature via DIM_OPCODE = -1
+        W[self.COMMIT_ID, DIM_ONE] = 1.0
+        W[self.COMMIT_ID, DIM_OPCODE] = -1.0
+        # BRANCH_TAKEN: unique signature via DIM_OPCODE = -2
+        W[self.BRANCH_TAKEN_ID, DIM_ONE] = 1.0
+        W[self.BRANCH_TAKEN_ID, DIM_OPCODE] = -2.0
+        # BRANCH_NOT_TAKEN: unique signature via DIM_OPCODE = -3
+        W[self.BRANCH_NOT_TAKEN_ID, DIM_ONE] = 1.0
+        W[self.BRANCH_NOT_TAKEN_ID, DIM_OPCODE] = -3.0
+
+        # Opcode tokens — match embed_program_token(pos=0, Instruction(op, 0))
+        for op_code, tid in self._opcode_to_tid.items():
+            W[tid, DIM_IS_PROG] = 1.0
+            W[tid, DIM_OPCODE] = float(op_code)
+            W[tid, DIM_ONE] = 1.0
+            dim = OPCODE_DIM_MAP.get(op_code)
+            if dim is not None and dim < d_model:
+                W[tid, dim] = 1.0
+
+        # Value tokens — match embed_stack_entry(addr=0, value=v, write_order=0)
+        # DIM_IS_STACK marks these as value-type (matching embed_stack_entry)
+        for v in range(256):
+            tid = self._VALUE_BASE + v
+            W[tid, DIM_IS_STACK] = 1.0
+            W[tid, DIM_VALUE] = float(v)
+            W[tid, DIM_ONE] = 1.0
+
+        # SP delta tokens — DIM_IS_STATE marks these as state-type (matching embed_state)
+        for delta in range(self._SP_DELTA_MIN, self._SP_DELTA_MAX + 1):
+            tid = self._SP_DELTA_BASE + (delta - self._SP_DELTA_MIN)
+            W[tid, DIM_IS_STATE] = 1.0
+            W[tid, DIM_SP] = float(delta)
+            W[tid, DIM_ONE] = 1.0
+
+        emb.weight = nn.Parameter(W, requires_grad=False)
+        return emb
+
+    def compile_unembedding(self, embedding=None, d_model=None):
+        """Build nn.Linear unembedding head s.t. argmax(unembed(embed(tok))) == tok.
+
+        Uses the transpose of the embedding matrix as the unembedding weight,
+        with per-token bias correction to handle varying embedding norms.
+
+        Args:
+            embedding: nn.Embedding from compile_embedding(). If None, builds one.
+            d_model: model dimension (used only if embedding is None).
+
+        Returns:
+            nn.Linear(d_model, vocab_size) with frozen weights.
+        """
+        if d_model is None:
+            d_model = D_MODEL
+        if embedding is None:
+            embedding = self.compile_embedding(d_model)
+
+        E = embedding.weight.data  # (vocab_size, d_model)
+        unembed = nn.Linear(d_model, self.vocab_size, bias=True)
+
+        # W = E, bias = -0.5 * ||e_i||^2  →  score_i = e_i · x - 0.5||e_i||^2
+        # This is equivalent to finding the nearest embedding by dot product,
+        # corrected for norm differences.
+        norms_sq = (E * E).sum(dim=1)  # (vocab_size,)
+        unembed.weight = nn.Parameter(E.clone(), requires_grad=False)
+        unembed.bias = nn.Parameter(-0.5 * norms_sq, requires_grad=False)
+
+        return unembed
+
+    def opcode_name(self, op_code):
+        """Human-readable name for an opcode."""
+        return OP_NAMES.get(op_code, f"?{op_code}")
+
+    def token_name(self, tid):
+        """Human-readable name for a token ID."""
+        tag, val = self.decode(tid)
+        if tag == self.SPECIAL:
+            return val
+        elif tag == self.OPCODE:
+            return self.opcode_name(val)
+        elif tag == self.VALUE:
+            return f"V{val}"
+        elif tag == self.SP_DELTA:
+            return f"SP{'+' if val >= 0 else ''}{val}"
+        return f"?{tid}"
+
+    def __repr__(self):
+        return (f"TokenVocab(vocab_size={self.vocab_size}, "
+                f"opcodes={len(self._opcode_to_tid)}, "
+                f"values=256, sp_deltas={self._SP_DELTA_COUNT}, "
+                f"specials={self._SPECIAL_COUNT})")
+
+
 # ─── Compiled Attention Head (from phase12) ───────────────────────
 
 class CompiledAttentionHead(nn.Module):


### PR DESCRIPTION
## Summary

- Adds `TokenVocab` class to `isa.py` with 323 tokens covering all 55 opcodes + TRAP, byte values 0–255, SP deltas -3..+3, and 4 special tokens (PAD, COMMIT, BRANCH_TAKEN, BRANCH_NOT_TAKEN)
- `encode(token) → int` and `decode(int) → token` for bidirectional mapping with structured token tuples (e.g. `("op", OP_PUSH)`, `("val", 42)`, `("sp_delta", -1)`)
- `compile_embedding()` builds `nn.Embedding(323, 51)` with analytically set weights matching existing `embed_program_token(pos=0)` and `embed_stack_entry(addr=0)` output
- `compile_unembedding()` builds `nn.Linear(51, 323)` using E^T with norm-correcting bias, achieving 100% round-trip accuracy (`argmax(unembed(embed(tok_id))) == tok_id` for all 323 tokens)
- All existing `test_consolidated.py` tests pass unchanged

Closes #45

## Test plan

- [x] Encode/decode round-trip for all 323 tokens
- [x] All token IDs unique and contiguous in [0, 323)
- [x] Opcode embeddings match `embed_program_token(pos=0, Instruction(op, 0))` on DIM_OPCODE, DIM_IS_PROG, DIM_ONE, and DIM_IS_* flags
- [x] Value embeddings match `embed_stack_entry(addr=0, value=v, write_order=0)` on DIM_VALUE, DIM_IS_STACK
- [x] 100% round-trip: encode → embed → unembed → decode == identity for entire vocabulary
- [x] `test_consolidated.py` passes (all 3 test suites: numpy equivalence, torch equivalence, internal consistency)

https://claude.ai/code/session_01PK8LquEVMd9nMhs5JRWafG