### PR TITLE
Symbolic executor for branchless programs (issue #65 first pass)

### DIFF
--- a/symbolic_executor.py
+++ b/symbolic_executor.py
@@ -1,0 +1,337 @@
+"""Symbolic executor for branchless LAC programs (issue #65).
+
+Claim: for branchless straight-line programs over {PUSH, POP, DUP, SWAP,
+OVER, ROT, ADD, SUB, MUL}, the k-instruction sequence executed by LAC's
+k attention heads collapses to a single polynomial in the PUSH constants.
+This module makes the collapse mechanical: walk the program, carry a
+symbolic stack whose entries are `Poly` expressions, and emit whatever's
+on top when HALT fires.
+
+Each PUSH allocates a fresh symbolic variable (`x0`, `x1`, ...) so the
+output generalises across the concrete PUSH constants. `eval_at` plugs
+the real integers back in to verify against ``NumPyExecutor``.
+
+Out of scope (file as follow-ups):
+  - Control flow (JZ/JNZ/CALL/RETURN) — branching creates piecewise polys.
+  - Bitwise / division / comparisons — not a polynomial operation.
+  - Locals, heap, memory — no symbolic address model yet.
+  - Emitting W_Q/W_K/W_V themselves as expression trees (the issue's
+    longer-horizon export story). The claim about composition collapse
+    lives at the semantic level and doesn't need the tree export.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Mapping, Tuple
+
+import isa
+
+
+# ─── Poly ──────────────────────────────────────────────────────────
+#
+# Polynomial over integer-indexed symbolic variables with integer
+# coefficients. Canonical form: terms is a dict keyed by a monomial
+# (tuple of (var_idx, power) pairs, sorted by var_idx, powers > 0).
+# The empty tuple `()` is the constant monomial. Zero-coefficient
+# terms are dropped on construction so comparisons are value-equal
+# when the polynomials are mathematically equal.
+
+Monomial = Tuple[Tuple[int, int], ...]
+
+
+def _mono_mul(a: Monomial, b: Monomial) -> Monomial:
+    """Merge two monomials. Powers add; result is sorted by var index."""
+    if not a:
+        return b
+    if not b:
+        return a
+    merged: Dict[int, int] = {}
+    for v, p in a:
+        merged[v] = merged.get(v, 0) + p
+    for v, p in b:
+        merged[v] = merged.get(v, 0) + p
+    return tuple(sorted(merged.items()))
+
+
+def _mono_str(mono: Monomial) -> str:
+    if not mono:
+        return "1"
+    parts = []
+    for v, p in mono:
+        parts.append(f"x{v}" if p == 1 else f"x{v}^{p}")
+    return "·".join(parts)
+
+
+@dataclass(frozen=True)
+class Poly:
+    """Multivariate polynomial with integer coefficients.
+
+    `terms` maps a monomial (canonical-form tuple) to its coefficient.
+    Zero-coefficient entries are never stored.
+    """
+
+    terms: Mapping[Monomial, int]
+
+    @staticmethod
+    def _normalise(terms: Mapping[Monomial, int]) -> Dict[Monomial, int]:
+        return {m: int(c) for m, c in terms.items() if c != 0}
+
+    def __post_init__(self):
+        # Freeze a normalised copy. Doing it this way so callers can pass
+        # any mapping and still get the value-equality guarantee.
+        object.__setattr__(self, "terms", self._normalise(dict(self.terms)))
+
+    # ── Constructors ──────────────────────────────────────────
+
+    @classmethod
+    def constant(cls, c: int) -> "Poly":
+        if c == 0:
+            return cls({})
+        return cls({(): int(c)})
+
+    @classmethod
+    def variable(cls, idx: int) -> "Poly":
+        return cls({((int(idx), 1),): 1})
+
+    # ── Arithmetic ────────────────────────────────────────────
+
+    def __add__(self, other: "Poly") -> "Poly":
+        out: Dict[Monomial, int] = dict(self.terms)
+        for m, c in other.terms.items():
+            out[m] = out.get(m, 0) + c
+        return Poly(out)
+
+    def __sub__(self, other: "Poly") -> "Poly":
+        out: Dict[Monomial, int] = dict(self.terms)
+        for m, c in other.terms.items():
+            out[m] = out.get(m, 0) - c
+        return Poly(out)
+
+    def __neg__(self) -> "Poly":
+        return Poly({m: -c for m, c in self.terms.items()})
+
+    def __mul__(self, other: "Poly") -> "Poly":
+        out: Dict[Monomial, int] = {}
+        for ma, ca in self.terms.items():
+            for mb, cb in other.terms.items():
+                m = _mono_mul(ma, mb)
+                out[m] = out.get(m, 0) + ca * cb
+        return Poly(out)
+
+    # ── Inspection ────────────────────────────────────────────
+
+    def n_monomials(self) -> int:
+        return len(self.terms)
+
+    def variables(self) -> List[int]:
+        """Variable indices referenced by any monomial, sorted."""
+        seen = set()
+        for m in self.terms:
+            for v, _ in m:
+                seen.add(v)
+        return sorted(seen)
+
+    def eval_at(self, bindings: Mapping[int, int]) -> int:
+        """Substitute `bindings[i]` for each ``x_i`` and reduce to an int.
+
+        Missing variables raise KeyError — symbolic executors that emit
+        a variable per PUSH should pass one binding per PUSH.
+        """
+        total = 0
+        for mono, coeff in self.terms.items():
+            term = coeff
+            for v, p in mono:
+                term *= bindings[v] ** p
+            total += term
+        return int(total)
+
+    # ── Equality / display ────────────────────────────────────
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Poly):
+            return NotImplemented
+        return self.terms == other.terms
+
+    def __hash__(self) -> int:
+        return hash(tuple(sorted(self.terms.items())))
+
+    def __repr__(self) -> str:  # deterministic for tests
+        if not self.terms:
+            return "0"
+        # sort by (total degree, monomial) for readable output
+        def _key(item):
+            m, _ = item
+            return (sum(p for _, p in m), m)
+
+        pieces = []
+        for mono, coeff in sorted(self.terms.items(), key=_key):
+            ms = _mono_str(mono)
+            if ms == "1":
+                pieces.append(str(coeff))
+                continue
+            if coeff == 1:
+                pieces.append(ms)
+            elif coeff == -1:
+                pieces.append(f"-{ms}")
+            else:
+                pieces.append(f"{coeff}·{ms}")
+        # join with explicit signs
+        out = pieces[0]
+        for p in pieces[1:]:
+            if p.startswith("-"):
+                out += f" - {p[1:]}"
+            else:
+                out += f" + {p}"
+        return out
+
+
+# ─── SymbolicExecutor ──────────────────────────────────────────────
+
+# Opcodes this executor understands. Branchless straight-line polynomial-
+# closed ops only; anything else raises on encounter so the caller sees
+# a clean "out of scope" error instead of a silent mismatch.
+_POLY_OPS = {
+    isa.OP_PUSH, isa.OP_POP, isa.OP_DUP, isa.OP_HALT,
+    isa.OP_ADD, isa.OP_SUB, isa.OP_MUL,
+    isa.OP_SWAP, isa.OP_OVER, isa.OP_ROT, isa.OP_NOP,
+}
+
+
+@dataclass
+class SymbolicResult:
+    """Outcome of running a program symbolically.
+
+    ``top`` is the polynomial left on top of the stack after HALT (or at
+    the end of the trace if HALT is absent). ``stack`` is the full final
+    stack (bottom at index 0). ``n_heads`` is the number of instructions
+    executed — the "k heads" the issue talks about. ``bindings`` maps the
+    allocated variable indices back to the original PUSH constants.
+    """
+
+    top: Poly
+    stack: List[Poly]
+    n_heads: int
+    bindings: Dict[int, int]
+
+    def collapse_ratio(self) -> float:
+        """k_heads ÷ n_monomials in the top expression, after simplification.
+
+        Matches the issue's "9 heads → 1 monomial" style report. Returns
+        `inf` when the top collapses to zero (no monomials) — flagged by
+        callers who want a cleaner representation.
+        """
+        n = self.top.n_monomials()
+        if n == 0:
+            return float("inf")
+        return self.n_heads / n
+
+
+class SymbolicStackUnderflow(RuntimeError):
+    pass
+
+
+class SymbolicOpNotSupported(NotImplementedError):
+    pass
+
+
+def run_symbolic(prog: List[isa.Instruction]) -> SymbolicResult:
+    """Execute ``prog`` symbolically. One variable allocated per PUSH.
+
+    Polynomial composition happens eagerly so the final form is already
+    simplified — no separate simplification pass needed.
+    """
+    stack: List[Poly] = []
+    bindings: Dict[int, int] = {}
+    next_var = 0
+    n_heads = 0
+
+    def _pop() -> Poly:
+        if not stack:
+            raise SymbolicStackUnderflow("pop from empty stack")
+        return stack.pop()
+
+    for instr in prog:
+        op = instr.op
+        arg = instr.arg
+        if op not in _POLY_OPS:
+            name = isa.OP_NAMES.get(op, f"?{op}")
+            raise SymbolicOpNotSupported(
+                f"op {name!r} is not polynomial-closed; issue #65 scope is "
+                f"branchless straight-line programs"
+            )
+        if op == isa.OP_HALT:
+            # HALT terminates the trace; the issue's head counts match
+            # the number of instructions executed *before* HALT fires.
+            break
+        n_heads += 1
+        if op == isa.OP_NOP:
+            continue
+
+        if op == isa.OP_PUSH:
+            v = next_var
+            next_var += 1
+            bindings[v] = int(arg)
+            stack.append(Poly.variable(v))
+        elif op == isa.OP_POP:
+            _pop()
+        elif op == isa.OP_DUP:
+            if not stack:
+                raise SymbolicStackUnderflow("dup on empty stack")
+            stack.append(stack[-1])
+        elif op == isa.OP_ADD:
+            b = _pop(); a = _pop()
+            stack.append(a + b)
+        elif op == isa.OP_SUB:
+            b = _pop(); a = _pop()
+            stack.append(a - b)
+        elif op == isa.OP_MUL:
+            b = _pop(); a = _pop()
+            stack.append(a * b)
+        elif op == isa.OP_SWAP:
+            if len(stack) < 2:
+                raise SymbolicStackUnderflow("swap needs 2 entries")
+            stack[-1], stack[-2] = stack[-2], stack[-1]
+        elif op == isa.OP_OVER:
+            if len(stack) < 2:
+                raise SymbolicStackUnderflow("over needs 2 entries")
+            stack.append(stack[-2])
+        elif op == isa.OP_ROT:
+            if len(stack) < 3:
+                raise SymbolicStackUnderflow("rot needs 3 entries")
+            # [a, b, c] -> [b, c, a] (matches test_algorithm semantics)
+            a, b, c = stack[-3], stack[-2], stack[-1]
+            stack[-3], stack[-2], stack[-1] = b, c, a
+        else:  # pragma: no cover — guarded by _POLY_OPS
+            raise SymbolicOpNotSupported(f"unreachable: op {op}")
+
+    top = stack[-1] if stack else Poly.constant(0)
+    return SymbolicResult(top=top, stack=list(stack),
+                          n_heads=n_heads, bindings=bindings)
+
+
+# ─── Reporting helper ─────────────────────────────────────────────
+
+def collapse_report(prog: List[isa.Instruction], *,
+                    name: str = "") -> str:
+    """Run ``prog`` symbolically and return a one-line collapse summary.
+
+    Example::
+
+        PUSH 5; DUP;ADD;DUP;ADD;DUP;ADD;DUP;ADD  →  9 heads, 1 monomial, top = 16·x0
+    """
+    r = run_symbolic(prog)
+    prefix = f"{name}: " if name else ""
+    return (f"{prefix}{r.n_heads} heads → {r.top.n_monomials()} "
+            f"monomials, top = {r.top}")
+
+
+__all__ = [
+    "Poly",
+    "SymbolicExecutor",
+    "SymbolicResult",
+    "SymbolicStackUnderflow",
+    "SymbolicOpNotSupported",
+    "run_symbolic",
+    "collapse_report",
+]

--- a/test_symbolic_executor.py
+++ b/test_symbolic_executor.py
@@ -1,0 +1,260 @@
+"""Tests for symbolic_executor (issue #65).
+
+Cross-checks the symbolic executor against ``NumPyExecutor`` on a suite
+of branchless programs: for each program we run both executors and
+verify the symbolic top-of-stack (after substituting the allocated
+variables back to the PUSH constants) equals the numeric top.
+
+Also pins the two PoC examples from the issue so the collapse claims
+stay honest: ``PUSH 5; (DUP;ADD)×4`` must remain ``9 heads → 1 monomial``
+and ``PUSH 3; PUSH 7; ADD; DUP; ADD`` must remain ``5 heads → 2 monomials``.
+
+Run standalone (phase-file style)::
+
+    python test_symbolic_executor.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+import isa
+from executor import NumPyExecutor
+from isa import program
+from symbolic_executor import (
+    Poly,
+    SymbolicOpNotSupported,
+    SymbolicStackUnderflow,
+    collapse_report,
+    run_symbolic,
+)
+
+
+# ─── Poly unit tests ──────────────────────────────────────────────
+
+def test_poly_constant_zero_is_empty():
+    assert Poly.constant(0).terms == {}
+    assert Poly.constant(0).n_monomials() == 0
+
+
+def test_poly_add_combines_like_terms():
+    x = Poly.variable(0)
+    assert (x + x) == Poly({((0, 1),): 2})
+    assert (x + x - x - x) == Poly.constant(0)
+
+
+def test_poly_mul_distributes():
+    x = Poly.variable(0)
+    y = Poly.variable(1)
+    # (x + y)*(x - y) = x² - y²
+    expanded = (x + y) * (x - y)
+    assert expanded == Poly({((0, 2),): 1, ((1, 2),): -1})
+
+
+def test_poly_mul_merges_powers():
+    x = Poly.variable(0)
+    # x * x * x → x^3 with coefficient 1
+    assert (x * x * x) == Poly({((0, 3),): 1})
+
+
+def test_poly_eval_at_matches_arithmetic():
+    x, y = Poly.variable(0), Poly.variable(1)
+    p = (x + y) * (x + y) - x * x
+    # (x+y)² - x² = 2xy + y²
+    assert p.eval_at({0: 3, 1: 5}) == 2 * 3 * 5 + 25
+
+
+def test_poly_equality_is_value_based():
+    a = Poly({((0, 1),): 2, (): 3})
+    b = Poly({(): 3, ((0, 1),): 2})
+    assert a == b
+    # zero-coefficient entries don't change identity
+    assert Poly({((0, 1),): 0, (): 1}) == Poly.constant(1)
+
+
+# ─── SymbolicExecutor unit tests ──────────────────────────────────
+
+def test_poc_1_dup_add_chain():
+    """PoC example 1: 9 heads → 1 monomial, top = 16·x0."""
+    prog = program(("PUSH", 5), *([("DUP",), ("ADD",)] * 4), ("HALT",))
+    r = run_symbolic(prog)
+    assert r.n_heads == 9
+    assert r.top.n_monomials() == 1
+    assert r.top == Poly({((0, 1),): 16})
+    assert r.top.eval_at(r.bindings) == 80
+
+
+def test_poc_2_add_dup_add():
+    """PoC example 2: 5 heads → 2 monomials, top = 2·x0 + 2·x1."""
+    prog = program(("PUSH", 3), ("PUSH", 7), ("ADD",),
+                   ("DUP",), ("ADD",), ("HALT",))
+    r = run_symbolic(prog)
+    assert r.n_heads == 5
+    assert r.top.n_monomials() == 2
+    assert r.top == Poly({((0, 1),): 2, ((1, 1),): 2})
+    assert r.top.eval_at(r.bindings) == 20
+
+
+def test_sub_works():
+    prog = program(("PUSH", 10), ("PUSH", 3), ("SUB",), ("HALT",))
+    r = run_symbolic(prog)
+    # 10 - 3 = x0 - x1
+    assert r.top == Poly({((0, 1),): 1, ((1, 1),): -1})
+    assert r.top.eval_at(r.bindings) == 7
+
+
+def test_mul_produces_higher_degree():
+    prog = program(("PUSH", 3), ("PUSH", 4), ("MUL",), ("HALT",))
+    r = run_symbolic(prog)
+    # x0 * x1, single monomial, degree 2
+    assert r.top == Poly({((0, 1), (1, 1)): 1})
+    assert r.top.eval_at(r.bindings) == 12
+
+
+def test_swap_reorders():
+    prog = program(("PUSH", 2), ("PUSH", 7), ("SWAP",), ("SUB",), ("HALT",))
+    r = run_symbolic(prog)
+    # After swap: stack = [7, 2]; SUB → 7 - 2 → x1 - x0
+    assert r.top.eval_at(r.bindings) == 5
+
+
+def test_over_copies_second():
+    prog = program(("PUSH", 11), ("PUSH", 4), ("OVER",), ("HALT",))
+    r = run_symbolic(prog)
+    # stack = [11, 4, 11]; top = x0
+    assert r.top == Poly({((0, 1),): 1})
+    assert r.top.eval_at(r.bindings) == 11
+
+
+def test_rot_three_entries():
+    prog = program(("PUSH", 1), ("PUSH", 2), ("PUSH", 3),
+                   ("ROT",), ("HALT",))
+    r = run_symbolic(prog)
+    # [a, b, c] -> [b, c, a] ; top is now x0 (original bottom)
+    assert r.top.eval_at(r.bindings) == 1
+
+
+def test_nop_preserves_stack():
+    prog = program(("PUSH", 9), ("NOP",), ("HALT",))
+    r = run_symbolic(prog)
+    assert r.top.eval_at(r.bindings) == 9
+
+
+def test_unsupported_op_raises():
+    import pytest
+    prog = program(("PUSH", 2), ("PUSH", 3), ("DIV_S",), ("HALT",))
+    try:
+        run_symbolic(prog)
+    except SymbolicOpNotSupported as e:
+        assert "DIV_S" in str(e)
+    else:
+        raise AssertionError("expected SymbolicOpNotSupported for DIV_S")
+
+
+def test_pop_underflow_raises():
+    try:
+        run_symbolic(program(("POP",), ("HALT",)))
+    except SymbolicStackUnderflow:
+        pass
+    else:
+        raise AssertionError("expected SymbolicStackUnderflow")
+
+
+# ─── Cross-check against NumPyExecutor ────────────────────────────
+
+_BRANCHLESS_SUITE = [
+    ("single_push", program(("PUSH", 42), ("HALT",))),
+    ("push_dup", program(("PUSH", 7), ("DUP",), ("HALT",))),
+    ("simple_add", program(("PUSH", 3), ("PUSH", 4), ("ADD",), ("HALT",))),
+    ("poc_16x", program(("PUSH", 5),
+                         *([("DUP",), ("ADD",)] * 4), ("HALT",))),
+    ("poc_2x_plus_2y", program(("PUSH", 3), ("PUSH", 7), ("ADD",),
+                                 ("DUP",), ("ADD",), ("HALT",))),
+    ("simple_sub", program(("PUSH", 20), ("PUSH", 8), ("SUB",), ("HALT",))),
+    ("simple_mul", program(("PUSH", 6), ("PUSH", 7), ("MUL",), ("HALT",))),
+    ("swap_sub", program(("PUSH", 2), ("PUSH", 15), ("SWAP",),
+                          ("SUB",), ("HALT",))),
+    ("over_add", program(("PUSH", 10), ("PUSH", 5), ("OVER",),
+                          ("ADD",), ("HALT",))),
+    ("rot_pattern", program(("PUSH", 1), ("PUSH", 2), ("PUSH", 3),
+                             ("ROT",), ("HALT",))),
+    ("mixed_ops", program(("PUSH", 2), ("PUSH", 3), ("PUSH", 4),
+                           ("MUL",), ("ADD",), ("HALT",))),
+    ("square_via_dupmul",
+        program(("PUSH", 7), ("DUP",), ("MUL",), ("HALT",))),
+    ("sum_of_squares",
+        program(("PUSH", 3), ("DUP",), ("MUL",),
+                ("PUSH", 4), ("DUP",), ("MUL",),
+                ("ADD",), ("HALT",))),
+]
+
+
+def test_cross_check_numpy_executor():
+    """For every branchless program, the symbolic top substituted with
+    the original PUSH constants must match NumPyExecutor's top-of-stack."""
+    np_exec = NumPyExecutor()
+    failures = []
+    for name, prog in _BRANCHLESS_SUITE:
+        # Numeric trace
+        trace = np_exec.execute(prog)
+        numeric_top = trace.steps[-1].top if trace.steps else 0
+        # Symbolic
+        sym = run_symbolic(prog)
+        symbolic_top = sym.top.eval_at(sym.bindings) if sym.bindings else (
+            sym.top.eval_at({}) if sym.top.n_monomials() else 0
+        )
+        if numeric_top != symbolic_top:
+            failures.append(
+                f"{name}: numeric={numeric_top}  symbolic={symbolic_top}  "
+                f"(top poly = {sym.top}, bindings = {sym.bindings})"
+            )
+    assert not failures, "\n  ".join(["mismatches:"] + failures)
+
+
+# ─── Collapse report ──────────────────────────────────────────────
+
+def test_collapse_report_format():
+    msg = collapse_report(
+        program(("PUSH", 5), *([("DUP",), ("ADD",)] * 4), ("HALT",)),
+        name="DUP_ADD_x4",
+    )
+    assert msg.startswith("DUP_ADD_x4: ")
+    assert "9 heads" in msg
+    assert "1 monomial" in msg
+    assert "16·x0" in msg
+
+
+# ─── Runner ───────────────────────────────────────────────────────
+
+def _collect_tests():
+    return {name: obj for name, obj in globals().items()
+            if callable(obj) and name.startswith("test_")}
+
+
+def main():
+    tests = _collect_tests()
+    print(f"Running {len(tests)} tests from test_symbolic_executor.py")
+    passed = 0
+    failed = []
+    for name, fn in tests.items():
+        try:
+            fn()
+        except Exception as e:
+            failed.append((name, e))
+            print(f"  ✗ {name}: {type(e).__name__}: {e}")
+            continue
+        passed += 1
+        print(f"  ✓ {name}")
+    print(f"\n{passed}/{len(tests)} passed")
+    if failed:
+        return 1
+
+    # Print the collapse report for the PoC programs as a sanity banner.
+    print("\nCollapse report:")
+    for name, prog in _BRANCHLESS_SUITE:
+        print(f"  {collapse_report(prog, name=name)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

First pass on #65: a symbolic executor that walks a branchless LAC program, tracking each stack entry as a polynomial over the PUSH constants. The k-instruction sequence collapses to a single polynomial — the issue's headline claim — verified on every program in the test suite.

**PoC claims pinned:**
- \`PUSH 5; (DUP;ADD)×4\` → **9 heads → 1 monomial** (\`16·x₀\`, evaluates to 80)
- \`PUSH 3; PUSH 7; ADD; DUP; ADD\` → **5 heads → 2 monomials** (\`2·x₀ + 2·x₁\`, evaluates to 20)

## Scope

**In:** \`{PUSH, POP, DUP, SWAP, OVER, ROT, ADD, SUB, MUL, HALT, NOP}\` — all polynomial-closed on integer coefficients.

**Out (raises \`SymbolicOpNotSupported\`):** bitwise, division, comparisons, control flow, locals, heap, call stack. Punted per the user's direction — the collapse demo is the whole point; W_Q/W_K/W_V-as-expression-trees is architecturally bigger without strengthening the claim.

## What landed

- \`symbolic_executor.py\` — \`Poly\` (multivariate integer-coeff polynomial with canonical form, \`+ − · eval_at\`), \`run_symbolic\` (walks a program, allocates one variable per PUSH), \`collapse_report\` (one-line \`k heads → n monomials\` summary).
- \`test_symbolic_executor.py\` — 18 tests: Poly algebra, per-op semantics, PoC pins, and a cross-check that runs 13 branchless programs through both \`NumPyExecutor\` and the symbolic executor and asserts \`top.eval_at(bindings) == numeric_top\` on every one.

## Collapse report highlights

| program | k heads | n monomials | top |
|---|---|---|---|
| \`PUSH 5; (DUP;ADD)×4\` | 9 | 1 | \`16·x₀\` |
| \`PUSH 3; PUSH 7; ADD; DUP; ADD\` | 5 | 2 | \`2·x₀ + 2·x₁\` |
| \`PUSH a; DUP; MUL\` (a²) | 3 | 1 | \`x₀²\` |
| \`3² + 4² via DUP+MUL+ADD\` | 7 | 2 | \`x₀² + x₁²\` |
| \`PUSH a; PUSH b; PUSH c; MUL; ADD\` | 5 | 2 | \`x₀ + x₁·x₂\` |

## Test plan

- [x] \`python test_symbolic_executor.py\` — 18/18 passed
- [x] Cross-check: symbolic-with-bindings matches \`NumPyExecutor\` on all 13 suite programs

## Not done (file as follow-ups)

- Control flow (branching → piecewise polynomials; needs guarded-trace simplifier).
- Symbolic model of the FF layer itself (this PR treats ADD as primitive, same as the PoC).
- Emitting W_Q/W_K/W_V as expression trees — export-artifact shape, punted.
- eml-sr bottoming-out (\`compile_expr\` from eml-sr turns any polynomial into pure eml; trivial follow-up once this lands).

https://claude.ai/code/session_01RXazJRx3KidM3h2rw1z8NE