### PR TITLE
Program catalog × symbolic executor × eml-sr bridge (issue #65 follow-up)

### DIFF
--- a/dev/symbolic_collapse_report.md
+++ b/dev/symbolic_collapse_report.md
@@ -1,0 +1,66 @@
+# LAC program catalog — symbolic collapse report
+
+Snapshot of `python symbolic_programs_catalog.py` run with eml-sr on
+`PYTHONPATH`. Regenerate with:
+
+```bash
+PYTHONPATH=../eml-sr python symbolic_programs_catalog.py \
+    > dev/symbolic_collapse_report.md
+```
+
+This is the issue #65 demo: every branchless program in `programs.py`
+collapses to a single polynomial (the `poly` column), which then compiles
+to a pure-EML tree (`eml size`/`eml depth`). Non-branchless programs are
+classified by their first blocker so the report splits cleanly between
+what the symbolic executor handles natively and what it doesn't.
+
+Invariants pinned by `test_symbolic_programs_catalog.py`:
+
+- `dup_add_chain_x4`: **9 heads → 1 monomial**, top = `16*x0` — matches
+  the issue's headline collapse claim.
+- `add_dup_add`: **5 heads → 2 monomials**, top = `2*x0 + 2*x1` — second
+  PoC from the issue.
+- Every collapsed row satisfies `NumPy top == Poly.eval_at == eval_eml`.
+- Multiplication's EML cost (35 nodes, depth 8) matches Table 4 of
+  Odrzywolek 2026, so a drift here would flag an upstream change.
+
+---
+
+_15 collapsed, 4 blocked-by-branch, 7 blocked-by-opcode (total 26)._
+
+## Collapsed (branchless, polynomial-closed)
+
+| Program | k heads | # mono | poly | eml size | eml depth | match |
+|---|---:|---:|---|---:|---:|:-:|
+| `basic_add` | 3 | 2 | `x0 + x1` | 21 | 6 | ✓ |
+| `push_halt` | 1 | 1 | `x0` | 1 | 0 | ✓ |
+| `push_pop` | 3 | 1 | `x0` | 1 | 0 | ✓ |
+| `dup_add` | 3 | 1 | `2*x0` | 35 | 8 | ✓ |
+| `multi_add` | 5 | 3 | `x0 + x1 + x2` | 41 | 10 | ✓ |
+| `stack_depth` | 5 | 1 | `x0` | 1 | 0 | ✓ |
+| `overwrite` | 3 | 1 | `x1` | 1 | 0 | ✓ |
+| `complex` | 6 | 2 | `2*x1 + 2*x2` | 89 | 12 | ✓ |
+| `many_pushes` | 19 | 10 | `x0 + x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9` | 181 | 38 | ✓ |
+| `alternating` | 7 | 4 | `x0 + x1 + x2 + x3` | 61 | 14 | ✓ |
+| `native_multiply(3,7)` | 3 | 1 | `x0*x1` | 35 | 8 | ✓ |
+| `square_via_dupmul(9)` | 3 | 1 | `x0^2` | 43 | 12 | ✓ |
+| `sum_of_squares(3,4)` | 7 | 2 | `x0^2 + x1^2` | 105 | 16 | ✓ |
+| `dup_add_chain_x4` | 9 | 1 | `16*x0` | 35 | 8 | ✓ |
+| `add_dup_add` | 5 | 2 | `2*x0 + 2*x1` | 89 | 12 | ✓ |
+
+## Blocked (out of symbolic-executor scope)
+
+| Program | reason | blocker |
+|---|---|---|
+| `native_divmod(2,7)` | non-polynomial op | `DIV_S` |
+| `native_clz(16)` | non-polynomial op | `CLZ` |
+| `native_abs_unary(-3)` | non-polynomial op | `ABS` |
+| `native_neg(5)` | non-polynomial op | `NEG` |
+| `compare_lt_s(3,5)` | non-polynomial op | `LT_S` |
+| `bitwise_and(12,10)` | non-polynomial op | `AND` |
+| `fibonacci(5)` | control flow | `JNZ` |
+| `factorial(4)` | control flow | `JZ` |
+| `is_even(6)` | control flow | `JZ` |
+| `power_of_2(4)` | control flow | `JZ` |
+| `native_max(3,5)` | non-polynomial op | `GT_S` |
+

--- a/symbolic_programs_catalog.py
+++ b/symbolic_programs_catalog.py
@@ -1,0 +1,394 @@
+"""LAC program catalog → polynomial → EML tree (issue #65 follow-up).
+
+Bridges :mod:`symbolic_executor` (PR #66) to eml-sr's :mod:`eml_compiler`:
+for every branchless program in :mod:`programs`, run the symbolic executor,
+emit the top-of-stack polynomial as an elementary expression string, and
+compile that to a pure-EML tree — reporting tree size / depth and a
+three-way numeric cross-check against ``NumPyExecutor``.
+
+Non-branchless programs are still reported, classified by their blocker
+(a non-polynomial opcode like DIV_S, or control flow JZ/JNZ) rather than
+forced through the pipeline.
+
+The eml-sr import is optional. When it's on ``PYTHONPATH`` the full
+``weights → polynomial → single-operator expression`` story lands; when it
+isn't, the polynomial column is still emitted and the EML columns show
+``–``. Either way the module stands alone in the LAC repo.
+
+Run standalone::
+
+    PYTHONPATH=../eml-sr python symbolic_programs_catalog.py
+
+or, if the eml-sr spoke is checked out alongside::
+
+    python symbolic_programs_catalog.py
+
+Prints the markdown report to stdout. Tests live in
+``test_symbolic_programs_catalog.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import isa
+from executor import NumPyExecutor
+from isa import program
+from symbolic_executor import (
+    Poly,
+    SymbolicStackUnderflow,
+    run_symbolic,
+)
+
+try:  # eml-sr is a sibling spoke; optional for the cross-repo demo.
+    from eml_compiler import compile_expr, eval_eml, tree_depth, tree_size
+    _EML_AVAILABLE = True
+except ImportError:  # pragma: no cover — flagged in the report
+    _EML_AVAILABLE = False
+
+
+# ─── Poly → expression string emitter ─────────────────────────────
+
+def _mono_to_expr(mono, prefix: str = "x") -> str:
+    if not mono:
+        return "1"
+    parts = [f"{prefix}{v}" if p == 1 else f"{prefix}{v}^{p}"
+             for v, p in mono]
+    return "*".join(parts)
+
+
+def poly_to_expr(poly: Poly, var_prefix: str = "x") -> str:
+    """Emit a :class:`Poly` as an elementary expression string.
+
+    Output uses ``+ - * ^`` — the grammar :func:`eml_compiler.compile_expr`
+    accepts. An empty :class:`Poly` (the canonical zero) renders as ``"0"``.
+    Negative coefficients render as ``- term`` rather than ``+ (-1)*term``
+    so the output round-trips cleanly through the parser.
+    """
+    if not poly.terms:
+        return "0"
+    ordered = sorted(
+        poly.terms.items(),
+        key=lambda kv: (sum(p for _, p in kv[0]), kv[0]),
+    )
+    out: List[str] = []
+    for i, (mono, coeff) in enumerate(ordered):
+        ms = _mono_to_expr(mono, var_prefix)
+        negative = coeff < 0
+        c = abs(coeff)
+        if ms == "1":
+            term = str(c)
+        elif c == 1:
+            term = ms
+        else:
+            term = f"{c}*{ms}"
+        if i == 0:
+            out.append(f"-{term}" if negative else term)
+        else:
+            out.append(f"- {term}" if negative else f"+ {term}")
+    return " ".join(out)
+
+
+# ─── Classification ───────────────────────────────────────────────
+
+_POLY_OPS = {
+    isa.OP_PUSH, isa.OP_POP, isa.OP_DUP, isa.OP_HALT,
+    isa.OP_ADD, isa.OP_SUB, isa.OP_MUL,
+    isa.OP_SWAP, isa.OP_OVER, isa.OP_ROT, isa.OP_NOP,
+}
+# Control flow — symbolic-executor scope excludes these even though the
+# taken path would technically evaluate. Reported separately so the
+# blocked rows split cleanly into "needs piecewise polys" (control flow)
+# vs "out of the polynomial ring" (comparisons, bitwise, division).
+_BRANCH_OPS = {isa.OP_JZ, isa.OP_JNZ}
+
+
+@dataclass
+class ClassificationResult:
+    status: str                         # "collapsed" | "blocked_opcode"
+                                        # | "blocked_control" | "blocked_underflow"
+    blocker: Optional[str] = None
+    poly: Optional[Poly] = None
+    n_heads: int = 0
+    bindings: Dict[int, int] = field(default_factory=dict)
+
+
+def classify_program(prog) -> ClassificationResult:
+    """Pre-flight check + symbolic execute. First blocker wins.
+
+    Walks the instruction list once before invoking :func:`run_symbolic` so
+    the blocked case reports the distinct ``blocked_control`` label — the
+    executor itself only knows "not polynomial-closed".
+    """
+    for instr in prog:
+        op = instr.op
+        if op in _BRANCH_OPS:
+            return ClassificationResult(
+                status="blocked_control",
+                blocker=isa.OP_NAMES.get(op, f"?{op}"),
+            )
+        if op not in _POLY_OPS:
+            return ClassificationResult(
+                status="blocked_opcode",
+                blocker=isa.OP_NAMES.get(op, f"?{op}"),
+            )
+    try:
+        r = run_symbolic(prog)
+    except SymbolicStackUnderflow as e:
+        return ClassificationResult(status="blocked_underflow", blocker=str(e))
+    return ClassificationResult(
+        status="collapsed", poly=r.top,
+        n_heads=r.n_heads, bindings=r.bindings,
+    )
+
+
+# ─── Catalog ──────────────────────────────────────────────────────
+
+@dataclass
+class CatalogEntry:
+    name: str
+    prog: Any
+    expected: Any  # programs.py returns an int; None for trap cases
+
+
+def _default_catalog() -> List[CatalogEntry]:
+    """Default set of programs piped through the catalog.
+
+    Mix of branchless PoCs (Phase 4 test_* + ``make_native_multiply`` +
+    a couple of hand-written squaring/cross-sum polynomials) and blocked
+    cases chosen to exercise every branch in :func:`classify_program`.
+    """
+    import programs as P
+
+    entries: List[CatalogEntry] = []
+
+    # Phase 4 branchless programs
+    for name, fn in P.ALL_TESTS:
+        prog, expected = fn()
+        entries.append(CatalogEntry(name=name, prog=prog, expected=expected))
+
+    # Parametric branchless, multiplicative
+    prog, expected = P.make_native_multiply(3, 7)
+    entries.append(CatalogEntry("native_multiply(3,7)", prog, expected))
+
+    # Squaring via DUP + MUL — single-monomial, degree 2
+    entries.append(CatalogEntry(
+        name="square_via_dupmul(9)",
+        prog=program(("PUSH", 9), ("DUP",), ("MUL",), ("HALT",)),
+        expected=81,
+    ))
+
+    # Sum of squares — two monomials, each degree 2
+    entries.append(CatalogEntry(
+        name="sum_of_squares(3,4)",
+        prog=program(
+            ("PUSH", 3), ("DUP",), ("MUL",),
+            ("PUSH", 4), ("DUP",), ("MUL",),
+            ("ADD",), ("HALT",),
+        ),
+        expected=25,
+    ))
+
+    # Issue #65 PoC pins
+    entries.append(CatalogEntry(
+        name="dup_add_chain_x4",
+        prog=program(("PUSH", 5),
+                     *([("DUP",), ("ADD",)] * 4), ("HALT",)),
+        expected=80,
+    ))
+    entries.append(CatalogEntry(
+        name="add_dup_add",
+        prog=program(("PUSH", 3), ("PUSH", 7), ("ADD",),
+                     ("DUP",), ("ADD",), ("HALT",)),
+        expected=20,
+    ))
+
+    # Blocked — non-polynomial opcodes
+    entries.append(CatalogEntry("native_divmod(2,7)",   *P.make_native_divmod(2, 7)))
+    entries.append(CatalogEntry("native_clz(16)",       *P.make_native_clz(16)))
+    entries.append(CatalogEntry("native_abs_unary(-3)", *P.make_native_abs_unary(-3)))
+    entries.append(CatalogEntry("native_neg(5)",        *P.make_native_neg(5)))
+    entries.append(CatalogEntry(
+        "compare_lt_s(3,5)",
+        *P.make_compare_binary(isa.OP_LT_S, 3, 5),
+    ))
+    entries.append(CatalogEntry(
+        "bitwise_and(12,10)",
+        *P.make_bitwise_binary(isa.OP_AND, 12, 10),
+    ))
+
+    # Blocked — control flow
+    entries.append(CatalogEntry("fibonacci(5)",  *P.make_fibonacci(5)))
+    entries.append(CatalogEntry("factorial(4)",  *P.make_factorial(4)))
+    entries.append(CatalogEntry("is_even(6)",    *P.make_is_even(6)))
+    entries.append(CatalogEntry("power_of_2(4)", *P.make_power_of_2(4)))
+    entries.append(CatalogEntry("native_max(3,5)", *P.make_native_max(3, 5)))
+
+    return entries
+
+
+# ─── Runner + row ────────────────────────────────────────────────
+
+@dataclass
+class CatalogRow:
+    name: str
+    status: str
+    blocker: Optional[str] = None
+    n_heads: int = 0
+    n_monomials: Optional[int] = None
+    poly_expr: Optional[str] = None
+    eml_size: Optional[int] = None
+    eml_depth: Optional[int] = None
+    numpy_top: Optional[int] = None
+    numeric_match: Optional[bool] = None
+
+
+def _numpy_top(np_exec: NumPyExecutor, prog) -> Optional[int]:
+    try:
+        trace = np_exec.execute(prog)
+    except Exception:  # trap / underflow — don't block the row
+        return None
+    return trace.steps[-1].top if trace.steps else None
+
+
+def run_catalog(entries: Optional[List[CatalogEntry]] = None, *,
+                np_exec: Optional[NumPyExecutor] = None) -> List[CatalogRow]:
+    """Classify every entry, populate EML columns where possible.
+
+    For ``collapsed`` rows the three-way cross-check is
+    ``NumPy top == Poly.eval_at(bindings) == eval_eml(compiled_tree)`` —
+    ``numeric_match`` is True only when all three agree.
+    """
+    entries = entries if entries is not None else _default_catalog()
+    np_exec = np_exec or NumPyExecutor()
+    rows: List[CatalogRow] = []
+    for entry in entries:
+        row = CatalogRow(name=entry.name, status="")
+        cr = classify_program(entry.prog)
+        row.status = cr.status
+        row.blocker = cr.blocker
+        row.n_heads = cr.n_heads
+        row.numpy_top = _numpy_top(np_exec, entry.prog)
+
+        if cr.status != "collapsed":
+            rows.append(row)
+            continue
+
+        assert cr.poly is not None
+        row.n_monomials = cr.poly.n_monomials()
+        row.poly_expr = poly_to_expr(cr.poly)
+
+        sym_val = cr.poly.eval_at(cr.bindings) if cr.bindings else 0
+        if cr.poly.n_monomials() and not cr.bindings:
+            # constant Poly — bindings may still be empty, evaluate at {}
+            sym_val = cr.poly.eval_at({})
+        checks = [row.numpy_top == sym_val]
+
+        if _EML_AVAILABLE:
+            vars_in_poly = cr.poly.variables()
+            if vars_in_poly:
+                tree = compile_expr(
+                    row.poly_expr,
+                    variables=[f"x{v}" for v in vars_in_poly],
+                )
+                eml_bindings = {f"x{v}": cr.bindings[v] for v in vars_in_poly}
+            else:
+                tree = compile_expr(row.poly_expr)
+                eml_bindings = {}
+            row.eml_size = tree_size(tree)
+            row.eml_depth = tree_depth(tree)
+            eml_val = eval_eml(tree, eml_bindings)
+            checks.append(
+                abs(eml_val.imag) < 1e-6
+                and int(round(eml_val.real)) == sym_val
+            )
+
+        row.numeric_match = all(checks)
+        rows.append(row)
+    return rows
+
+
+# ─── Reporting ────────────────────────────────────────────────────
+
+_BLOCK_REASON = {
+    "blocked_control":   "control flow",
+    "blocked_opcode":    "non-polynomial op",
+    "blocked_underflow": "stack underflow",
+}
+
+
+def format_report(rows: List[CatalogRow]) -> str:
+    """Render a markdown-style catalog report from :func:`run_catalog` rows."""
+    n_collapsed = sum(1 for r in rows if r.status == "collapsed")
+    n_control = sum(1 for r in rows if r.status == "blocked_control")
+    n_opcode = sum(1 for r in rows if r.status == "blocked_opcode")
+    n_other = len(rows) - n_collapsed - n_control - n_opcode
+
+    lines = [
+        "# LAC program catalog — symbolic collapse report",
+        "",
+        f"_{n_collapsed} collapsed, {n_control} blocked-by-branch, "
+        f"{n_opcode} blocked-by-opcode"
+        + (f", {n_other} other" if n_other else "")
+        + f" (total {len(rows)})._",
+        "",
+    ]
+    if not _EML_AVAILABLE:
+        lines += ["_eml-sr not on PYTHONPATH — eml tree columns show `–`._", ""]
+
+    lines += [
+        "## Collapsed (branchless, polynomial-closed)",
+        "",
+        "| Program | k heads | # mono | poly | eml size | eml depth | match |",
+        "|---|---:|---:|---|---:|---:|:-:|",
+    ]
+    for r in rows:
+        if r.status != "collapsed":
+            continue
+        size = "–" if r.eml_size is None else str(r.eml_size)
+        depth = "–" if r.eml_depth is None else str(r.eml_depth)
+        ok = "–" if r.numeric_match is None else ("✓" if r.numeric_match else "✗")
+        lines.append(
+            f"| `{r.name}` | {r.n_heads} | {r.n_monomials} | "
+            f"`{r.poly_expr}` | {size} | {depth} | {ok} |"
+        )
+
+    lines += [
+        "",
+        "## Blocked (out of symbolic-executor scope)",
+        "",
+        "| Program | reason | blocker |",
+        "|---|---|---|",
+    ]
+    for r in rows:
+        if r.status == "collapsed" or r.status == "":
+            continue
+        reason = _BLOCK_REASON.get(r.status, r.status)
+        lines.append(f"| `{r.name}` | {reason} | `{r.blocker}` |")
+
+    return "\n".join(lines) + "\n"
+
+
+# ─── CLI ──────────────────────────────────────────────────────────
+
+def main() -> int:
+    rows = run_catalog()
+    print(format_report(rows))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+    sys.exit(main())
+
+
+__all__ = [
+    "CatalogEntry",
+    "CatalogRow",
+    "ClassificationResult",
+    "classify_program",
+    "format_report",
+    "poly_to_expr",
+    "run_catalog",
+]

--- a/test_symbolic_programs_catalog.py
+++ b/test_symbolic_programs_catalog.py
@@ -1,0 +1,262 @@
+"""Tests for symbolic_programs_catalog (issue #65 follow-up).
+
+Covers the three pieces of the bridge:
+
+1. ``poly_to_expr`` emits strings that parse cleanly and evaluate to the
+   same integer as ``Poly.eval_at``.
+2. ``classify_program`` lands on the right bucket — collapsed, blocked by
+   a non-polynomial opcode, or blocked by control flow — for a handful of
+   hand-picked programs.
+3. ``run_catalog`` produces a row for every entry whose ``numeric_match``
+   field is True on the collapsed subset (the LAC ↔ eml-sr pipeline).
+
+The eml-sr cross-checks are skipped when the compiler isn't importable so
+this file still passes with just the LAC repo checked out. Run standalone::
+
+    python test_symbolic_programs_catalog.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+import isa
+from executor import NumPyExecutor
+from isa import program
+from symbolic_executor import Poly
+from symbolic_programs_catalog import (
+    _EML_AVAILABLE,
+    CatalogEntry,
+    classify_program,
+    poly_to_expr,
+    run_catalog,
+)
+
+
+# ─── poly_to_expr ─────────────────────────────────────────────────
+
+def test_poly_to_expr_empty_is_zero():
+    assert poly_to_expr(Poly.constant(0)) == "0"
+
+
+def test_poly_to_expr_constant_positive():
+    assert poly_to_expr(Poly.constant(7)) == "7"
+
+
+def test_poly_to_expr_single_variable():
+    assert poly_to_expr(Poly.variable(0)) == "x0"
+
+
+def test_poly_to_expr_sum_with_coefficients():
+    p = Poly({((0, 1),): 2, ((1, 1),): 2})
+    assert poly_to_expr(p) == "2*x0 + 2*x1"
+
+
+def test_poly_to_expr_negative_coefficient():
+    p = Poly({((0, 1),): 1, ((1, 1),): -1})  # x0 - x1
+    assert poly_to_expr(p) == "x0 - x1"
+
+
+def test_poly_to_expr_leading_negative():
+    p = Poly({((0, 1),): -3, ((1, 1),): 2})  # -3*x0 + 2*x1
+    assert poly_to_expr(p) == "-3*x0 + 2*x1"
+
+
+def test_poly_to_expr_higher_degree():
+    p = Poly({((0, 2),): 1, ((1, 2),): -1})  # x0^2 - x1^2
+    assert poly_to_expr(p) == "x0^2 - x1^2"
+
+
+def test_poly_to_expr_mixed_monomial():
+    p = Poly({((0, 1), (1, 1)): 3})
+    assert poly_to_expr(p) == "3*x0*x1"
+
+
+# ─── classify_program ─────────────────────────────────────────────
+
+def test_classify_collapsed_branchless():
+    cr = classify_program(program(
+        ("PUSH", 5),
+        *([("DUP",), ("ADD",)] * 4),
+        ("HALT",),
+    ))
+    assert cr.status == "collapsed"
+    assert cr.n_heads == 9
+    assert cr.poly == Poly({((0, 1),): 16})
+
+
+def test_classify_blocks_control_flow():
+    # PUSH 3, DUP, JZ 99, HALT — first JZ wins
+    prog = [
+        isa.Instruction(isa.OP_PUSH, 3),
+        isa.Instruction(isa.OP_DUP),
+        isa.Instruction(isa.OP_JZ, 99),
+        isa.Instruction(isa.OP_HALT),
+    ]
+    cr = classify_program(prog)
+    assert cr.status == "blocked_control"
+    assert cr.blocker == "JZ"
+
+
+def test_classify_blocks_nonpolynomial_opcode():
+    # PUSH 2, PUSH 7, DIV_S, HALT
+    prog = [
+        isa.Instruction(isa.OP_PUSH, 2),
+        isa.Instruction(isa.OP_PUSH, 7),
+        isa.Instruction(isa.OP_DIV_S),
+        isa.Instruction(isa.OP_HALT),
+    ]
+    cr = classify_program(prog)
+    assert cr.status == "blocked_opcode"
+    assert cr.blocker == "DIV_S"
+
+
+def test_classify_first_blocker_wins():
+    # LT_S precedes JZ — non-polynomial opcode is reported even though
+    # control flow also appears further down.
+    prog = [
+        isa.Instruction(isa.OP_PUSH, 3),
+        isa.Instruction(isa.OP_PUSH, 5),
+        isa.Instruction(isa.OP_LT_S),
+        isa.Instruction(isa.OP_JZ, 99),
+        isa.Instruction(isa.OP_HALT),
+    ]
+    cr = classify_program(prog)
+    assert cr.status == "blocked_opcode"
+    assert cr.blocker == "LT_S"
+
+
+# ─── run_catalog — end-to-end pipeline ────────────────────────────
+
+def test_run_catalog_default_has_collapsed_and_blocked():
+    rows = run_catalog()
+    n_collapsed = sum(1 for r in rows if r.status == "collapsed")
+    n_blocked = sum(1 for r in rows if r.status.startswith("blocked"))
+    assert n_collapsed >= 10, f"expected ≥10 collapsed rows, got {n_collapsed}"
+    assert n_blocked >= 5, f"expected ≥5 blocked rows, got {n_blocked}"
+
+
+def test_run_catalog_collapsed_rows_numeric_match():
+    """Every collapsed row's 3-way check (NumPy ≡ Poly ≡ EML) must pass.
+
+    Degenerates to a 2-way check (NumPy ≡ Poly) when eml-sr is not on
+    the path, which is still a meaningful guard.
+    """
+    rows = run_catalog()
+    failures = [r for r in rows
+                if r.status == "collapsed" and r.numeric_match is not True]
+    assert not failures, (
+        "numeric_match false on: "
+        + ", ".join(f"{r.name}={r.numeric_match}" for r in failures)
+    )
+
+
+def test_run_catalog_pins_poc_collapse_counts():
+    rows = {r.name: r for r in run_catalog()}
+    # These two pins trace back to the issue #65 PoC text and must not drift.
+    assert rows["dup_add_chain_x4"].n_heads == 9
+    assert rows["dup_add_chain_x4"].n_monomials == 1
+    assert rows["dup_add_chain_x4"].poly_expr == "16*x0"
+    assert rows["add_dup_add"].n_heads == 5
+    assert rows["add_dup_add"].n_monomials == 2
+    assert rows["add_dup_add"].poly_expr == "2*x0 + 2*x1"
+
+
+def test_run_catalog_single_entry_override():
+    """Custom entry list is honored instead of the default catalog."""
+    entry = CatalogEntry(
+        name="x0_plus_x1",
+        prog=program(("PUSH", 2), ("PUSH", 5), ("ADD",), ("HALT",)),
+        expected=7,
+    )
+    rows = run_catalog([entry])
+    assert len(rows) == 1
+    assert rows[0].status == "collapsed"
+    assert rows[0].n_heads == 3
+    assert rows[0].n_monomials == 2
+    assert rows[0].numpy_top == 7
+    assert rows[0].numeric_match is True
+
+
+# ─── Cross-repo bridge — skipped when eml-sr unavailable ──────────
+
+def test_poly_to_expr_round_trips_through_eml_compiler():
+    if not _EML_AVAILABLE:
+        print("  (eml-sr not available — skipping round-trip test)")
+        return
+    from eml_compiler import compile_expr, eval_eml
+
+    p = Poly({((0, 1),): 2, ((1, 1),): 2})  # 2*x0 + 2*x1
+    tree = compile_expr(poly_to_expr(p), variables=["x0", "x1"])
+    val = eval_eml(tree, {"x0": 3, "x1": 7})
+    assert abs(val.imag) < 1e-6
+    assert int(round(val.real)) == p.eval_at({0: 3, 1: 7}) == 20
+
+
+def test_collapsed_rows_have_eml_tree_sizes_when_available():
+    """EML tree size/depth should be populated for every collapsed row
+    when the compiler is importable."""
+    if not _EML_AVAILABLE:
+        print("  (eml-sr not available — skipping eml-tree test)")
+        return
+    rows = run_catalog()
+    for r in rows:
+        if r.status != "collapsed":
+            continue
+        assert r.eml_size is not None and r.eml_size >= 1, r.name
+        assert r.eml_depth is not None and r.eml_depth >= 0, r.name
+
+
+def test_known_eml_shapes_match_paper():
+    """Sanity pins for the two EML identities the paper gives explicitly:
+
+    - ``x*y`` compiles to a 35-node, depth-8 tree (Table 4).
+    - ``x + y`` compiles to a 21-node, depth-6 tree.
+
+    Not strictly invariants of *this* module — they're invariants of
+    eml_compiler — but a drift here would indicate the upstream
+    identity table changed, which is load-bearing for our report
+    numbers.
+    """
+    if not _EML_AVAILABLE:
+        print("  (eml-sr not available — skipping paper-shape test)")
+        return
+    from eml_compiler import compile_expr, tree_depth, tree_size
+
+    mul_tree = compile_expr("x*y", variables=["x", "y"])
+    assert tree_size(mul_tree) == 35
+    assert tree_depth(mul_tree) == 8
+
+    add_tree = compile_expr("x + y", variables=["x", "y"])
+    assert tree_size(add_tree) == 21
+    assert tree_depth(add_tree) == 6
+
+
+# ─── Runner ───────────────────────────────────────────────────────
+
+def _collect_tests():
+    return {name: obj for name, obj in globals().items()
+            if callable(obj) and name.startswith("test_")}
+
+
+def main() -> int:
+    tests = _collect_tests()
+    print(f"Running {len(tests)} tests from test_symbolic_programs_catalog.py")
+    print(f"  (eml-sr available: {_EML_AVAILABLE})")
+    passed = 0
+    failed = []
+    for name, fn in tests.items():
+        try:
+            fn()
+        except Exception as e:
+            failed.append((name, e))
+            print(f"  ✗ {name}: {type(e).__name__}: {e}")
+            continue
+        passed += 1
+        print(f"  ✓ {name}")
+    print(f"\n{passed}/{len(tests)} passed")
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Follow-up to #66 (merged). Closes the LAC ↔ eml-sr arc the issue hinted at: every branchless program in `programs.py` is classified, collapsed to a single polynomial, and (when the eml-sr spoke is importable) compiled to a pure-EML tree — end-to-end numeric cross-check against `NumPyExecutor`.

## What's here

- `symbolic_programs_catalog.py` — `poly_to_expr`, `classify_program`, `run_catalog`, `format_report`, CLI. The eml-sr import is optional; without it the polynomial column still renders and the EML columns show `–`.
- `test_symbolic_programs_catalog.py` — 19 tests covering the emitter, classifier, PoC invariants, and the three-way `NumPy ≡ Poly ≡ EML` cross-check. Tests skip eml-sr-specific assertions when the compiler isn't importable so the file passes with just the LAC repo checked out.
- `dev/symbolic_collapse_report.md` — reviewable snapshot of the rendered report.

## Catalog snapshot

**15 / 26** programs collapse cleanly. Headline rows:

| Program | k heads | monos | poly | EML size | EML depth |
|---|---:|---:|---|---:|---:|
| `dup_add_chain_x4` (issue #65 PoC) | 9 | 1 | `16*x0` | 35 | 8 |
| `add_dup_add` (issue #65 PoC) | 5 | 2 | `2*x0 + 2*x1` | 89 | 12 |
| `native_multiply(3,7)` | 3 | 1 | `x0*x1` | 35 | 8 |
| `square_via_dupmul(9)` | 3 | 1 | `x0^2` | 43 | 12 |
| `many_pushes` | 19 | 10 | `x0 + … + x9` | 181 | 38 |

The remaining 11 rows are blocked, split between **control flow** (`fibonacci`, `factorial`, `is_even`, `power_of_2` — all hit JZ/JNZ) and **non-polynomial opcodes** (`DIV_S`, `CLZ`, `ABS`, `NEG`, `LT_S`, `AND`, `GT_S`). The classifier reports first-blocker-wins, so e.g. `native_max(3,5)` shows up as `GT_S` rather than `JZ` even though both appear.

## Test plan

- [x] `python test_symbolic_programs_catalog.py` → 19/19 pass (eml-sr on PYTHONPATH)
- [x] `python test_symbolic_programs_catalog.py` → 19/19 pass (eml-sr NOT importable; 3 eml-specific tests self-skip)
- [x] `python test_symbolic_executor.py` → 18/18 pass (no regression)
- [x] `PYTHONPATH=../eml-sr python symbolic_programs_catalog.py` matches `dev/symbolic_collapse_report.md`

## What this closes / defers

**Closes** the story of #65's first pass: the collapse claim is now demonstrated across a representative slice of the programs catalog, not just the two hand-picked PoCs.

**Deferred** (documented in `dev/FINDINGS.md`-adjacent — not this PR):
- FF layer as a symbolic model (per-opcode dispatch as a polynomial too).
- Control flow via guarded traces (branch → piecewise Poly per path).
- Division / comparison as rational or sign-indicator extensions to `Poly`.

https://claude.ai/code/session_01RXazJRx3KidM3h2rw1z8NE