### PR TITLE
S3: cross-check bilinear FF over guarded + unrolled rows (issue #68)

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -906,6 +906,20 @@ class CompiledModel(nn.Module):
         """
         return ff_symbolic.evaluate_program(prog)
 
+    def forward_symbolic_forking(self, prog, *, input_mode="symbolic"):
+        """Run ``prog`` through the forking executor with the bilinear-FF
+        primitives (issue #68 S3).
+
+        Extends :meth:`forward_symbolic` past the branchless fragment by
+        delegating to :func:`ff_symbolic.evaluate_program_forking`, which
+        drives :func:`symbolic_executor.run_forking` with this module's
+        ADD/SUB/MUL ops. Accepts JZ/JNZ — returns a
+        :class:`symbolic_executor.ForkingResult` whose ``top`` is a
+        :class:`Poly` (straight-line / unrolled) or
+        :class:`symbolic_executor.GuardedPoly` (guarded).
+        """
+        return ff_symbolic.evaluate_program_forking(prog, input_mode=input_mode)
+
 
 # ─── PyTorch Executor ────────────────────────────────────────────
 

--- a/ff_symbolic.py
+++ b/ff_symbolic.py
@@ -62,7 +62,12 @@ import torch
 
 import isa
 from isa import DIM_VALUE, D_MODEL, DTYPE
-from symbolic_executor import Poly
+from symbolic_executor import (
+    ArithmeticOps,
+    ForkingResult,
+    Poly,
+    run_forking,
+)
 
 
 # ─── Exceptions ────────────────────────────────────────────────────
@@ -245,6 +250,20 @@ def symbolic_mul(pa: Poly, pb: Poly) -> Poly:
     return pa * pb
 
 
+# Triple of bilinear-FF primitives, packaged for
+# :func:`symbolic_executor.run_forking`'s ``arithmetic_ops`` hook
+# (issue #68 S3). ``symbolic_sub`` returns ``pb - pa`` to match the
+# FF dispatch order (``va`` is top, ``vb`` is stack[SP-1]); the
+# forking executor's internal order is ``a - b`` where ``a`` is
+# stack[SP-1] and ``b`` is top, so we bind ``sub=lambda a, b:
+# symbolic_sub(b, a)`` to keep the two orders aligned.
+FF_ARITHMETIC_OPS = ArithmeticOps(
+    add=lambda a, b: symbolic_add(a, b),
+    sub=lambda a, b: symbolic_sub(b, a),
+    mul=lambda a, b: symbolic_mul(a, b),
+)
+
+
 # ─── Program-level symbolic forward ───────────────────────────────
 #
 # ``CompiledModel.forward_symbolic`` delegates to :func:`evaluate_program`
@@ -348,6 +367,30 @@ def evaluate_program(prog) -> SymbolicForwardResult:
                                  n_heads=n_heads, bindings=bindings)
 
 
+def evaluate_program_forking(prog, *, input_mode: str = "symbolic") -> ForkingResult:
+    """Run ``prog`` through :func:`symbolic_executor.run_forking` with the
+    bilinear-FF ADD/SUB/MUL primitives (issue #68 S3).
+
+    The control-flow driver (JZ/JNZ, worklist, path merging) is shared
+    with the symbolic executor's native call; only the arithmetic
+    primitives differ — they're routed through this module's
+    :func:`symbolic_add` / :func:`symbolic_sub` / :func:`symbolic_mul`,
+    the Poly-level interpretation of ``M_ADD`` / ``M_SUB`` / ``B_MUL``.
+
+    Returns a :class:`symbolic_executor.ForkingResult`. For guarded
+    programs the ``top`` is a :class:`symbolic_executor.GuardedPoly`;
+    for unrolled or straight-line programs it's a :class:`Poly`.
+
+    The equivalence claim (structural): for every catalog program
+    accepted by the forking executor, this function's output is
+    structurally equal to :func:`symbolic_executor.run_forking`'s.
+    Verified by ``test_ff_symbolic.test_equivalence_guarded_*`` and
+    ``_equivalence_unrolled_*``.
+    """
+    return run_forking(prog, input_mode=input_mode,
+                       arithmetic_ops=FF_ARITHMETIC_OPS)
+
+
 __all__ = [
     "BlockedOpcodeForSymbolic",
     "RangeCheckFailure",
@@ -357,7 +400,9 @@ __all__ = [
     "n_parameters",
     "forward_add", "forward_sub", "forward_mul",
     "symbolic_add", "symbolic_sub", "symbolic_mul",
+    "FF_ARITHMETIC_OPS",
     "SymbolicForwardResult",
     "evaluate_program",
+    "evaluate_program_forking",
     "range_check",
 ]

--- a/symbolic_executor.py
+++ b/symbolic_executor.py
@@ -40,7 +40,7 @@ Out of scope (file as follow-ups):
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Mapping, Optional, Tuple, Union
+from typing import Callable, Dict, List, Mapping, Optional, Tuple, Union
 
 import isa
 
@@ -452,6 +452,44 @@ def run_symbolic(prog: List[isa.Instruction]) -> SymbolicResult:
                           n_heads=n_heads, bindings=bindings)
 
 
+# ─── Arithmetic hook (issue #68 S3) ───────────────────────────────
+#
+# ``run_forking`` calls three arithmetic primitives in its inner loop —
+# one each for ADD, SUB, MUL. The default primitives are ``Poly``'s
+# native ``+ - *``; the forking driver is indifferent to which
+# implementation is plugged in as long as the signature is ``(Poly,
+# Poly) -> Poly`` and the algebra is the same.
+#
+# The hook exists so :mod:`ff_symbolic` can drive the same forking
+# executor with its bilinear-FF interpretation of the primitives
+# (``symbolic_add/sub/mul``) and demonstrate the equivalence claim
+# from issue #69 extends across JZ/JNZ control flow — not just
+# branchless straight-line programs.
+
+
+ArithFn = Callable[["Poly", "Poly"], "Poly"]
+
+
+@dataclass(frozen=True)
+class ArithmeticOps:
+    """Three-operator spec the forking executor consumes for ADD/SUB/MUL.
+
+    ``sub(a, b)`` must return ``a - b`` (executor computes ``a - b``
+    where ``a`` is the second-from-top, matching the existing Poly
+    order). ``ff_symbolic.symbolic_sub`` matches this spec.
+    """
+    add: ArithFn
+    sub: ArithFn
+    mul: ArithFn
+
+
+DEFAULT_ARITHMETIC_OPS = ArithmeticOps(
+    add=lambda a, b: a + b,
+    sub=lambda a, b: a - b,
+    mul=lambda a, b: a * b,
+)
+
+
 # ─── Forking executor (issue #70) ─────────────────────────────────
 
 # Default caps. Catalog programs stay under these comfortably; the
@@ -536,7 +574,8 @@ def _eq_guard(p: Poly, eq_zero: bool) -> Guard:
 def run_forking(prog: List[isa.Instruction], *,
                 input_mode: str = "symbolic",
                 max_paths: int = DEFAULT_MAX_PATHS,
-                max_steps: int = DEFAULT_MAX_STEPS) -> ForkingResult:
+                max_steps: int = DEFAULT_MAX_STEPS,
+                arithmetic_ops: Optional[ArithmeticOps] = None) -> ForkingResult:
     """Forking symbolic executor with finite-conditional + bounded-loop support.
 
     ``input_mode``:
@@ -546,6 +585,12 @@ def run_forking(prog: List[isa.Instruction], *,
         All branches collapse deterministically; loops unroll naturally.
         Suitable for ``collapsed_unrolled``.
 
+    ``arithmetic_ops``: override the ADD/SUB/MUL primitives applied to
+    Poly stack entries. Defaults to :data:`DEFAULT_ARITHMETIC_OPS` (plain
+    Poly ``+ - *``). :mod:`ff_symbolic` passes its bilinear-FF
+    interpretation here (issue #68 S3) to demonstrate equivalence across
+    control flow.
+
     The executor uses a worklist. Each fork splits the path into two new
     paths carrying complementary guards. When a path's top polynomial is
     concrete at a branch, the branch is followed deterministically. A
@@ -554,6 +599,7 @@ def run_forking(prog: List[isa.Instruction], *,
     """
     if input_mode not in ("symbolic", "concrete"):
         raise ValueError(f"unknown input_mode {input_mode!r}")
+    ops = arithmetic_ops if arithmetic_ops is not None else DEFAULT_ARITHMETIC_OPS
 
     # Pre-flight: reject programs with non-polynomial, non-branch opcodes.
     for instr in prog:
@@ -615,7 +661,7 @@ def run_forking(prog: List[isa.Instruction], *,
                 # Non-branch, non-halt → advance n_heads and apply op.
                 if op != isa.OP_JZ and op != isa.OP_JNZ:
                     try:
-                        stack = _apply_poly_op(path, instr, input_mode)
+                        stack = _apply_poly_op(path, instr, input_mode, ops)
                     except SymbolicStackUnderflow:
                         underflow_seen = True
                         # drop this path; don't propagate partial result
@@ -755,8 +801,14 @@ def run_forking(prog: List[isa.Instruction], *,
 
 
 def _apply_poly_op(path: _Path, instr: isa.Instruction,
-                   input_mode: str) -> Tuple[Poly, ...]:
-    """Apply a non-branch opcode to ``path.stack`` and return the new stack."""
+                   input_mode: str,
+                   arithmetic_ops: ArithmeticOps = DEFAULT_ARITHMETIC_OPS) -> Tuple[Poly, ...]:
+    """Apply a non-branch opcode to ``path.stack`` and return the new stack.
+
+    ``arithmetic_ops`` picks the ADD/SUB/MUL implementations. Defaults to
+    Poly's native operators; :mod:`ff_symbolic` passes its bilinear-FF
+    primitives.
+    """
     op = instr.op
     stack = list(path.stack)
 
@@ -778,13 +830,13 @@ def _apply_poly_op(path: _Path, instr: isa.Instruction,
         stack.append(stack[-1])
     elif op == isa.OP_ADD:
         b = _pop(); a = _pop()
-        stack.append(a + b)
+        stack.append(arithmetic_ops.add(a, b))
     elif op == isa.OP_SUB:
         b = _pop(); a = _pop()
-        stack.append(a - b)
+        stack.append(arithmetic_ops.sub(a, b))
     elif op == isa.OP_MUL:
         b = _pop(); a = _pop()
-        stack.append(a * b)
+        stack.append(arithmetic_ops.mul(a, b))
     elif op == isa.OP_SWAP:
         if len(stack) < 2:
             raise SymbolicStackUnderflow(f"swap needs 2 entries at pc={path.pc}")
@@ -861,6 +913,8 @@ __all__ = [
     "SymbolicOpNotSupported",
     "SymbolicLoopSymbolic",
     "SymbolicPathExplosion",
+    "ArithmeticOps",
+    "DEFAULT_ARITHMETIC_OPS",
     "DEFAULT_MAX_PATHS",
     "DEFAULT_MAX_STEPS",
     "run_symbolic",

--- a/test_ff_symbolic.py
+++ b/test_ff_symbolic.py
@@ -1,4 +1,4 @@
-"""Tests for ff_symbolic (issue #69).
+"""Tests for ff_symbolic (issue #69 + issue #68 S3).
 
 Verifies the bilinear FF dispatch realises the same polynomial the symbolic
 executor emits — not just numerically, but *structurally*. For every
@@ -7,12 +7,19 @@ collapsed catalog program, the test asserts
 equality (value-compare), alongside a numerical agreement check against
 :class:`NumPyExecutor` on concrete inputs.
 
+S3 extends the cross-check past the branchless fragment: guarded programs
+(JZ/JNZ on symbolic conditions) and unrolled programs (bounded loops at
+concrete inputs) are driven through the forking executor with the bilinear
+FF primitives, and compared structurally against the symbolic executor's
+native ``run_forking``.
+
 Layout:
   * ``test_primitives_*`` — unit-level checks on E / M_ADD / M_SUB / B_MUL.
   * ``test_range_check`` — Option (a) bound enforcement.
   * ``test_equivalence_*`` — the core equivalence theorem, parametrised
     over every row in ``symbolic_programs_catalog`` whose status is
-    ``STATUS_COLLAPSED``.
+    ``STATUS_COLLAPSED``. The ``_guarded_*`` / ``_unrolled_*`` variants
+    cover ``STATUS_COLLAPSED_GUARDED`` / ``STATUS_COLLAPSED_UNROLLED``.
   * ``test_blocked_opcodes`` — non-polynomial ops are rejected rather than
     silently returning a wrong-but-plausible Poly.
 """
@@ -29,9 +36,11 @@ import ff_symbolic as ff
 import isa
 from executor import CompiledModel, NumPyExecutor
 from isa import DIM_VALUE, program
-from symbolic_executor import Poly, run_symbolic
+from symbolic_executor import GuardedPoly, Poly, run_forking, run_symbolic
 from symbolic_programs_catalog import (
     STATUS_COLLAPSED,
+    STATUS_COLLAPSED_GUARDED,
+    STATUS_COLLAPSED_UNROLLED,
     _default_catalog,
     classify_program,
 )
@@ -160,6 +169,37 @@ def _collapsed_entries():
     return out
 
 
+def _guarded_entries():
+    """Catalog entries classified STATUS_COLLAPSED_GUARDED.
+
+    Exercises the S3 cross-check (issue #68): bilinear FF primitives
+    must produce the same :class:`GuardedPoly` as the symbolic executor
+    when JZ/JNZ branches fork on symbolic conditions.
+    """
+    out = []
+    for entry in _default_catalog():
+        cr = classify_program(entry.prog)
+        if cr.status == STATUS_COLLAPSED_GUARDED and cr.guarded is not None:
+            out.append((entry, cr))
+    return out
+
+
+def _unrolled_entries():
+    """Catalog entries classified STATUS_COLLAPSED_UNROLLED.
+
+    Exercises the S3 cross-check (issue #68): bilinear FF primitives
+    under ``input_mode="concrete"`` must produce the same final Poly
+    the symbolic executor produces when bounded loops unroll under
+    concrete inputs.
+    """
+    out = []
+    for entry in _default_catalog():
+        cr = classify_program(entry.prog)
+        if cr.status == STATUS_COLLAPSED_UNROLLED:
+            out.append((entry, cr))
+    return out
+
+
 def test_equivalence_structural():
     """Core equivalence: forward_symbolic.top == run_symbolic.top, per catalog row.
 
@@ -211,6 +251,152 @@ def test_equivalence_numeric():
             f"numeric[{entry.name}]",
             sym_val == np_top,
             f"sym_val={sym_val}, np_top={np_top}",
+        )
+
+
+# ─── Guarded / unrolled equivalence (issue #68 S3) ────────────────
+#
+# Structural: the forking executor with the bilinear FF primitives
+# plugged in must produce the same ``top`` (a :class:`Poly` or
+# :class:`GuardedPoly`) as the symbolic executor's native ``run_forking``.
+# ``symbolic_add/sub/mul`` are defined as the Poly-level interpretation
+# of ``M_ADD`` / ``M_SUB`` / ``B_MUL``; S3 extends the equivalence past
+# branchless straight-line code into JZ/JNZ control flow and bounded
+# loop unrolling.
+#
+# Numeric: the live case's value polynomial, evaluated at the concrete
+# bindings, must equal :class:`NumPyExecutor`'s top. The compiled
+# transformer's numeric forward path already routes ADD/SUB/MUL through
+# ``forward_add/sub/mul`` (see ``executor.py`` lines 826-833), so this
+# check completes the three-way agreement per guarded / unrolled row.
+
+
+def test_equivalence_guarded_structural():
+    """Forking FF == forking symbolic, structurally, on every guarded row."""
+    model = CompiledModel()
+    entries = _guarded_entries()
+    _check("catalog has guarded entries", len(entries) > 0,
+           f"expected >0, got {len(entries)}")
+    for entry, _cr in entries:
+        sym = run_forking(entry.prog, input_mode="symbolic")
+        ff_res = model.forward_symbolic_forking(entry.prog, input_mode="symbolic")
+        _check(
+            f"guarded.status[{entry.name}]",
+            sym.status == ff_res.status,
+            f"sym={sym.status}, ff={ff_res.status}",
+        )
+        _check(
+            f"guarded.top[{entry.name}]",
+            sym.top == ff_res.top,
+            f"sym.top={sym.top!r} vs ff.top={ff_res.top!r}",
+        )
+        _check(
+            f"guarded.n_heads[{entry.name}]",
+            sym.n_heads == ff_res.n_heads,
+            f"sym={sym.n_heads}, ff={ff_res.n_heads}",
+        )
+
+
+def test_equivalence_guarded_numeric():
+    """For the live case under the catalog's bindings: sym == np == ff-numeric.
+
+    The FF-wired numeric forward path runs each trace step through the
+    bilinear matrices; ``TorchExecutor`` drives that loop. The three-way
+    agreement here is the numeric counterpart of the structural claim.
+    """
+    from executor import TorchExecutor
+    model = CompiledModel()
+    np_exec = NumPyExecutor()
+    torch_exec = TorchExecutor(model)
+    for entry, cr in _guarded_entries():
+        guarded: GuardedPoly = cr.guarded  # type: ignore[assignment]
+        bindings = cr.bindings
+        if not bindings:
+            continue  # no concrete bindings → nothing to evaluate numerically
+
+        np_trace = np_exec.execute(entry.prog)
+        np_top = np_trace.steps[-1].top if np_trace.steps else None
+        t_trace = torch_exec.execute(entry.prog)
+        t_top = t_trace.steps[-1].top if t_trace.steps else None
+
+        try:
+            sym_val = guarded.eval_at(bindings)
+        except ValueError as e:
+            _fail(f"guarded.numeric[{entry.name}]", f"eval_at: {e}")
+            continue
+        _check(
+            f"guarded.sym==np[{entry.name}]",
+            sym_val == np_top,
+            f"sym={sym_val}, np={np_top}",
+        )
+        _check(
+            f"guarded.np==ff[{entry.name}]",
+            np_top == t_top,
+            f"np={np_top}, ff(numeric)={t_top}",
+        )
+
+
+def test_equivalence_unrolled_structural():
+    """Forking FF == forking symbolic, structurally, on every unrolled row.
+
+    Uses ``input_mode="concrete"`` — matches how ``classify_program``
+    collapses unrolled programs.
+    """
+    model = CompiledModel()
+    entries = _unrolled_entries()
+    _check("catalog has unrolled entries", len(entries) > 0,
+           f"expected >0, got {len(entries)}")
+    for entry, _cr in entries:
+        sym = run_forking(entry.prog, input_mode="concrete")
+        ff_res = model.forward_symbolic_forking(entry.prog, input_mode="concrete")
+        _check(
+            f"unrolled.status[{entry.name}]",
+            sym.status == ff_res.status,
+            f"sym={sym.status}, ff={ff_res.status}",
+        )
+        _check(
+            f"unrolled.top[{entry.name}]",
+            sym.top == ff_res.top,
+            f"sym.top={sym.top!r} vs ff.top={ff_res.top!r}",
+        )
+        _check(
+            f"unrolled.n_heads[{entry.name}]",
+            sym.n_heads == ff_res.n_heads,
+            f"sym={sym.n_heads}, ff={ff_res.n_heads}",
+        )
+
+
+def test_equivalence_unrolled_numeric():
+    """sym (eval'd at concrete bindings) == np == ff-numeric per unrolled row."""
+    from executor import TorchExecutor
+    model = CompiledModel()
+    np_exec = NumPyExecutor()
+    torch_exec = TorchExecutor(model)
+    for entry, cr in _unrolled_entries():
+        np_trace = np_exec.execute(entry.prog)
+        np_top = np_trace.steps[-1].top if np_trace.steps else None
+        t_trace = torch_exec.execute(entry.prog)
+        t_top = t_trace.steps[-1].top if t_trace.steps else None
+
+        if cr.poly is not None:
+            # Concrete-mode polys have no free variables (every PUSH
+            # specialised to its literal); eval_at({}) collapses them.
+            sym_val = cr.poly.eval_at({})
+        elif cr.guarded is not None:
+            # Rare: unrolled program still produced guarded output.
+            sym_val = cr.guarded.eval_at({}) if not cr.guarded.variables() else None
+        else:
+            sym_val = None
+        if sym_val is not None:
+            _check(
+                f"unrolled.sym==np[{entry.name}]",
+                sym_val == np_top,
+                f"sym={sym_val}, np={np_top}",
+            )
+        _check(
+            f"unrolled.np==ff[{entry.name}]",
+            np_top == t_top,
+            f"np={np_top}, ff(numeric)={t_top}",
         )
 
 
@@ -299,6 +485,10 @@ def main():
         test_range_check,
         test_equivalence_structural,
         test_equivalence_numeric,
+        test_equivalence_guarded_structural,
+        test_equivalence_guarded_numeric,
+        test_equivalence_unrolled_structural,
+        test_equivalence_unrolled_numeric,
         test_dup_add_chain_pin,
         test_sum_of_squares_pin,
         test_blocked_opcodes,


### PR DESCRIPTION
## Summary

Closes **S3** from the issue-#68 roadmap: extend `test_ff_symbolic.py` past the branchless fragment so the issue-#69 equivalence theorem holds structurally and numerically on every `collapsed_guarded` and `collapsed_unrolled` row.

## Plumbing

- `symbolic_executor.run_forking` gains an optional `arithmetic_ops: ArithmeticOps` hook. Default stays Poly's native `+ - *`; the forking driver is indifferent to the implementation as long as the spec matches.
- `ff_symbolic.FF_ARITHMETIC_OPS` packages `symbolic_add/sub/mul` for that hook. `sub` is bound as `lambda a, b: symbolic_sub(b, a)` to align the executor's argument order (`a - b`) with ff_symbolic's FF-spec order (`pb - pa`).
- `ff_symbolic.evaluate_program_forking(prog, input_mode=...)` calls `run_forking` with those primitives.
- `CompiledModel.forward_symbolic_forking(prog, input_mode=...)` exposes it at the model level.

## Tests

Extends `test_ff_symbolic.py` with four new tests parametrised over the catalog:

- `test_equivalence_guarded_structural` — `GuardedPoly` case-table equality (status + top + n_heads) between `run_forking` and `forward_symbolic_forking`.
- `test_equivalence_guarded_numeric` — live case's value poly = NumPyExecutor top = TorchExecutor top (three-way agreement, the FF-wired numeric path already uses the bilinear matrices per `executor.py:826-833`).
- `test_equivalence_unrolled_structural` / `_numeric` — same two claims for bounded-loop rows driven with `input_mode=\"concrete\"`.

With today's catalog the new tests cover **3 guarded** (`select_by_sign`, `clamp_zero`, `either_or`) and **4 unrolled** (`fibonacci(5)`, `factorial(4)`, `is_even(6)`, `power_of_2(4)`) rows. New catalog rows in those statuses are picked up automatically.

## Test plan

- [x] `python3 test_ff_symbolic.py` — all new + existing checks green.
- [x] `python3 test_symbolic_executor.py` — unchanged (17/18, one pre-existing failure due to missing `pytest` module, not touched).
- [x] `python3 test_symbolic_programs_catalog.py` — 27/27.
- [x] Reviewer spot-check: is the `sub` argument-order aliasing in `FF_ARITHMETIC_OPS` clear enough? The forking executor uses `a - b` (where `a` is second-from-top), while `symbolic_sub` returns `pb - pa` (where `pa` is top). Adapter wraps one as the other.

https://claude.ai/code/session_0128ieSwEiWTRG6RWB1YFab8