### PR TITLE
Rationals for DIV_S / REM_S (closes #75)

### DIFF
--- a/dev/ff_symbolic_equivalence.md
+++ b/dev/ff_symbolic_equivalence.md
@@ -1,6 +1,6 @@
 # FF symbolic equivalence — the weights ARE the polynomial
 
-_Issue #69 writeup. Follow-up to #65 (PR #66 symbolic executor, PR #67 catalog runner)._
+_Issue #69 writeup. Follow-up to #65 (PR #66 symbolic executor, PR #67 catalog runner). Extended by #75 to cover DIV_S / REM_S via rational-pair algebra._
 
 ## The claim, in one sentence
 
@@ -68,8 +68,11 @@ standard basis. That choice makes the three constructions direct:
 | MUL | Bilinear | `B_MUL[DIM_VALUE, DIM_VALUE] = 1` (rank-1 outer product) | `E(a)^T B_MUL E(b) = a·b`              |
 
 Every other entry in those matrices is zero. The total weight budget
-added by this module is three non-zero values; the blog post's "964
-compiled parameters" becomes 967.
+added by #69 is five non-zero values
+(`M_ADD: 2, M_SUB: 2, B_MUL: 1`); the blog post's "964 compiled
+parameters" becomes 969. Issue #75 adds four more (`M_DIV_S: 2,
+M_REM_S: 2`) for a total of nine — see the rational-extension
+section below.
 
 Under the scalar embedding, ADD and SUB are linear (because `E` is a
 linear map on `ℤ`) and MUL is bilinear (a degree-2 polynomial, which is
@@ -126,6 +129,82 @@ The check at `test_ff_symbolic.py::test_dup_add_chain_pin`
 pins this equality; the parametrised `test_equivalence_structural`
 generalises it to all 15 currently-collapsed catalog programs.
 
+## Rational extension (issue #75)
+
+Integer division and remainder aren't polynomial operations over ℤ, so
+the `{ADD, SUB, MUL}` story above — "the weight matrix _is_ the
+operator" — doesn't extend cleanly. Issue #75 keeps that spirit going
+by pushing the arithmetic into the rational field ℚ up to the final
+truncation step:
+
+- `symbolic_executor.Poly` coefficients widen from `int` to
+  `int | Fraction`. `_normalise` still collapses ratios with denominator
+  1 back to `int`, so every structural Poly equality test from #69
+  continues to compare pure-`int` coefficients. Fraction only appears
+  inside a `RationalPoly` / `SymbolicRemainder` wrapper.
+- Two minimal wrappers carry ``(num, denom)`` pairs through the
+  symbolic stack:
+
+  ```python
+  @dataclass(frozen=True)
+  class RationalPoly:       # DIV_S result
+      num: Poly
+      denom: Poly
+      def eval_at(self, bindings): return _trunc_div(num_val, denom_val)
+
+  @dataclass(frozen=True)
+  class SymbolicRemainder:  # REM_S result
+      num: Poly
+      denom: Poly
+      def eval_at(self, bindings): return _trunc_rem(num_val, denom_val)
+  ```
+
+  `eval_at` is where the non-polynomial truncation lives: we collapse
+  to ℤ only at the boundary, matching WASM `i32.div_s` / `i32.rem_s`
+  semantics.
+- `ff_symbolic.M_DIV_S` / `M_REM_S` are 2 × 2·d_model **pair-selector**
+  matrices — they pluck `(va, vb)` from the stacked `[E(a); E(b)]`
+  input and feed them to the boundary `_trunc_div(vb, va)` /
+  `_trunc_rem(vb, va)`. Two non-zero entries each; the weight budget
+  (non-zero entries across all five matrices) is
+  `M_ADD(2) + M_SUB(2) + B_MUL(1) + M_DIV_S(2) + M_REM_S(2) = 9`.
+- `symbolic_div_s` / `symbolic_rem_s` are the polynomial-side
+  interpretation: construct `RationalPoly(num=pb, denom=pa)` /
+  `SymbolicRemainder(num=pb, denom=pa)` with `(pa, pb) = (top, SP-1)`
+  matching the numeric argument order.
+
+The equivalence theorem for the rational fragment is weaker than the
+bilinear-form story of #69 because integer-truncating division is a
+**non-linear boundary step**. The honest statement is:
+
+> For every DIV_S / REM_S catalog program P and its concrete bindings,
+> `run_symbolic(P).top` and `forward_symbolic(P).top` are structurally
+> equal (same wrapper, same num, same denom), and each evaluates — via
+> `eval_at` — to the same integer that `NumPyExecutor(P).top` reports,
+> provided the dividend and divisor are both in the positive i32 range
+> (so NumPy's `& MASK32` doesn't perturb the equality).
+
+### Composition non-goal
+
+A second DIV_S / REM_S / ADD / SUB / MUL applied to a `RationalPoly`
+or `SymbolicRemainder` raises `SymbolicOpNotSupported`
+(`BlockedOpcodeForSymbolic` on the FF side). Supporting composition
+would require either (a) a proper rational-function algebra with GCD
+cancellation (rational coefficients are insufficient because the
+numerator / denominator can share symbolic factors) or (b) delaying
+truncation through every subsequent op, which is unsound. Neither is
+small. Left to a follow-up.
+
+### Catalog impact
+
+Two programs move from `blocked_opcode` to `collapsed`:
+`native_divmod(2, 7)` (a `RationalPoly` of `7 / 2` → 3) and
+`native_remainder(2, 7)` (a `SymbolicRemainder` of `7 mod 2` → 1). The
+`CatalogRow.is_rational` flag marks them; `poly_expr` renders as
+`"(pb) /ₜ (pa)"` / `"(pb) modₜ (pa)"`; eml-sr columns stay `–`
+because the single `eml(x, y) = exp(x) − ln(y)` operator has no
+division primitive.
+
 ## Honest limits
 
 ### Range / i32-wrap
@@ -156,7 +235,11 @@ and no division) and is deliberately out of scope.
 
 Listing these explicitly so the PR description stays honest:
 
-- **DIV_S / REM_S** — require rational-function algebra; out of scope.
+- **DIV_S / REM_S beyond a single op at the top of the stack** —
+  covered for terminal DIV_S / REM_S by issue #75 (pair-selector +
+  boundary trunc), but composition *past* a rational stack entry
+  still raises. Full rational-function algebra (with GCD cancellation)
+  is a follow-up.
 - **Comparisons** (EQ, LT_S, GT_S, …) — piecewise, need sign indicators
   and/or Heaviside gating; out of scope.
 - **Bitwise** (AND, OR, XOR, shifts, rotates) — different algebra (mod-2
@@ -211,9 +294,11 @@ provably.
 
 Each of these is a separate issue:
 
-- **Rational-function algebra** for `DIV_S` / `REM_S`. The FF layer gains
-  a bilinear form over `(num, denom)` pairs; `Poly` becomes
-  `RationalPoly`.
+- **Rational-function algebra with composition.** #75 handled the
+  terminal DIV_S / REM_S case; supporting ADD / SUB / MUL / DIV_S /
+  REM_S applied to an already-rational stack entry is the next bite.
+  Needs GCD-based cancellation in the `Poly` ring (or a `RationalPoly`
+  type with an explicit normal form).
 - **Piecewise bilinear forms** for comparisons. A sign-indicator
   attention pattern gates into one of two output branches — the FF
   counterpart of the symbolic executor's forking model (#70).
@@ -225,9 +310,14 @@ visible.
 
 ## References
 
-- Parent issue: #65 · follow-up: #69
+- Parent issue: #65 · follow-ups: #69, #75
 - Symbolic executor: PR #66
 - Catalog runner + eml bridge: PR #67
 - Forking / guarded execution: PR #71 (issue #70)
-- This PR: `ff_symbolic.py`, `executor.py` (ADD/SUB/MUL + `forward_symbolic`),
-  `test_ff_symbolic.py`, this writeup.
+- ADD/SUB/MUL bilinear forms: this module (issue #69).
+- DIV_S / REM_S rational extension: issue #75 — adds
+  `RationalPoly` / `SymbolicRemainder` to `symbolic_executor.py`,
+  `M_DIV_S` / `M_REM_S` + `forward_div_s` / `forward_rem_s` +
+  `symbolic_div_s` / `symbolic_rem_s` to `ff_symbolic.py`, rational
+  rows to `symbolic_programs_catalog.py`, and the rational section
+  above to this writeup.

--- a/dev/ff_symbolic_equivalence.md
+++ b/dev/ff_symbolic_equivalence.md
@@ -201,7 +201,7 @@ Two programs move from `blocked_opcode` to `collapsed`:
 `native_divmod(2, 7)` (a `RationalPoly` of `7 / 2` → 3) and
 `native_remainder(2, 7)` (a `SymbolicRemainder` of `7 mod 2` → 1). The
 `CatalogRow.is_rational` flag marks them; `poly_expr` renders as
-`"(pb) /ₜ (pa)"` / `"(pb) modₜ (pa)"`; eml-sr columns stay `–`
+`"(num) /ₜ (denom)"` / `"(num) %ₜ (denom)"`; eml-sr columns stay `–`
 because the single `eml(x, y) = exp(x) − ln(y)` operator has no
 division primitive.
 

--- a/ff_symbolic.py
+++ b/ff_symbolic.py
@@ -46,11 +46,34 @@ for continuity with :class:`executor.NumPyExecutor` (so
 ``test_consolidated.py`` stays green); the equivalence tests compare
 unmasked values on in-range inputs.
 
+Rational extension (issue #75)
+------------------------------
+DIV_S / REM_S are *not* polynomial. The workaround — and the content of
+issue #75 — is to keep the symbolic form rational (``RationalPoly`` /
+``SymbolicRemainder`` track ``(num, denom)`` pairs through the stack)
+and apply integer truncation only at the boundary, during
+``eval_at`` / ``forward_div_s`` evaluation.
+
+The "weight matrix" story for DIV_S / REM_S is therefore weaker than
+for ADD/SUB/MUL: ``M_DIV_S`` / ``M_REM_S`` are 2×2 *pair-selector*
+matrices that pluck the two scalar operands out of the stacked input,
+and the truncating division ``_trunc_div(vb, va)`` is a non-linear
+boundary step — not itself a matmul. That is the honest cost of
+integer-rounded division in a polynomial framework; the value of this
+extension is that the rational *algebra* (up to truncation) does
+compose cleanly, and the catalog's ``native_divmod`` / ``native_remainder``
+programs now have a closed-form symbolic top.
+
+Composition past a single DIV_S / REM_S on the same stack slot is not
+supported in this issue — a subsequent arithmetic op on a rational
+stack entry raises ``SymbolicOpNotSupported``. That is a follow-up.
+
 Scope
 -----
-This module handles ADD/SUB/MUL only. DIV_S, REM_S, comparisons,
-bitwise, unary numeric ops, control flow — all unchanged, and all
-explicit follow-ups per the issue's "Non-goals" section.
+ADD/SUB/MUL via true (bi)linear forms; DIV_S/REM_S via pair-selector
++ boundary trunc (issue #75). Comparisons, bitwise, unary numeric
+ops, control flow — all unchanged, and all explicit follow-ups per
+the issue's "Non-goals" section.
 """
 
 from __future__ import annotations
@@ -61,11 +84,14 @@ from typing import Dict, List, Optional, Tuple, Union
 import torch
 
 import isa
-from isa import DIM_VALUE, D_MODEL, DTYPE
+from isa import DIM_VALUE, D_MODEL, DTYPE, _trunc_div, _trunc_rem
 from symbolic_executor import (
     ArithmeticOps,
     ForkingResult,
     Poly,
+    RationalPoly,
+    RationalStackValue,
+    SymbolicRemainder,
     run_forking,
 )
 
@@ -176,21 +202,49 @@ def _B_MUL_matrix(d_model: int = D_MODEL) -> torch.Tensor:
     return B
 
 
+def _M_DIV_S_matrix(d_model: int = D_MODEL) -> torch.Tensor:
+    """Pair-selector for DIV_S: pluck ``(va, vb)`` from ``[E(a); E(b)]``.
+
+    Shape: ``(2, 2*d_model)``. Row 0 picks ``va = ea[DIM_VALUE]`` (the top),
+    row 1 picks ``vb = eb[DIM_VALUE]`` (stack[SP-1]). The subsequent
+    ``_trunc_div(vb, va)`` is a *non-linear boundary step* — unlike
+    ``M_ADD`` / ``M_SUB`` / ``B_MUL``, this matrix alone does not
+    realise the op. Its role is to expose, at the weight level, that
+    the FF receives exactly the two scalars and nothing else.
+    """
+    W = torch.zeros(2, 2 * d_model, dtype=DTYPE)
+    W[0, DIM_VALUE] = 1.0                   # va
+    W[1, d_model + DIM_VALUE] = 1.0         # vb
+    return W
+
+
+def _M_REM_S_matrix(d_model: int = D_MODEL) -> torch.Tensor:
+    """Pair-selector for REM_S: identical shape/role to :func:`_M_DIV_S_matrix`.
+
+    The boundary nonlinearity is ``_trunc_rem(vb, va)``.
+    """
+    W = torch.zeros(2, 2 * d_model, dtype=DTYPE)
+    W[0, DIM_VALUE] = 1.0
+    W[1, d_model + DIM_VALUE] = 1.0
+    return W
+
+
 # Module-scope cached tensors — read-only; wrapped on access.
 M_ADD: torch.Tensor = _M_ADD_matrix()
 M_SUB: torch.Tensor = _M_SUB_matrix()
 B_MUL: torch.Tensor = _B_MUL_matrix()
+M_DIV_S: torch.Tensor = _M_DIV_S_matrix()
+M_REM_S: torch.Tensor = _M_REM_S_matrix()
 
 
 def n_parameters(d_model: int = D_MODEL) -> int:
-    """Parameter count contributed by ``M_ADD``, ``M_SUB``, ``B_MUL``.
+    """Parameter count contributed by the analytically-set FF weights.
 
-    Counts the actual non-zero entries (3) — the dense shapes hold only
-    these three symbolic "slots". The blog post's "964 compiled parameters"
-    figure should become ``964 + 3`` after this module lands; the stored
-    tensors are larger but the analytically-set content is three bits.
+    Counts non-zero entries: 2 (M_ADD) + 2 (M_SUB) + 1 (B_MUL) + 2 (M_DIV_S)
+    + 2 (M_REM_S) = 9. The stored tensors are larger but the analytically-set
+    content is nine bits. Pre-#75 the count was 3 (ADD/SUB/MUL only).
     """
-    return 3
+    return 9
 
 
 # ─── Numeric primitives (float tensors) ───────────────────────────
@@ -224,6 +278,42 @@ def forward_mul(ea: torch.Tensor, eb: torch.Tensor) -> torch.Tensor:
     return out
 
 
+def forward_div_s(ea: torch.Tensor, eb: torch.Tensor) -> torch.Tensor:
+    """Compute ``E(trunc_div(vb, va))`` from ``E(a), E(b)``.
+
+    Applies ``M_DIV_S`` as a pair-selector (``[va, vb] = M_DIV_S @ stacked``)
+    and then the truncating integer division ``_trunc_div(vb, va)`` — the
+    non-linear boundary step that polynomial algebra cannot express.
+    Matches the existing numeric path in ``executor.py:836``:
+    ``_trunc_div(vb, va)`` with ``va`` = top, ``vb`` = stack[SP-1].
+    """
+    stacked = torch.cat([ea, eb])                 # shape (2*d_model,)
+    pair = M_DIV_S @ stacked                      # shape (2,): [va, vb]
+    va = int(round(float(pair[0].item())))
+    vb = int(round(float(pair[1].item())))
+    q = _trunc_div(vb, va)                        # boundary nonlinearity
+    out = torch.zeros(ea.shape[0], dtype=DTYPE)
+    out[DIM_VALUE] = float(q)
+    return out
+
+
+def forward_rem_s(ea: torch.Tensor, eb: torch.Tensor) -> torch.Tensor:
+    """Compute ``E(trunc_rem(vb, va))`` from ``E(a), E(b)``.
+
+    Same pair-selector pattern as :func:`forward_div_s`; the boundary
+    nonlinearity is ``_trunc_rem(vb, va)`` (sign-of-dividend remainder,
+    matching WASM ``i32.rem_s``).
+    """
+    stacked = torch.cat([ea, eb])
+    pair = M_REM_S @ stacked
+    va = int(round(float(pair[0].item())))
+    vb = int(round(float(pair[1].item())))
+    r = _trunc_rem(vb, va)
+    out = torch.zeros(ea.shape[0], dtype=DTYPE)
+    out[DIM_VALUE] = float(r)
+    return out
+
+
 # ─── Symbolic primitives (Poly values) ────────────────────────────
 #
 # These ARE polynomial algebra — ``Poly`` overloads ``+ - *`` — but they
@@ -250,17 +340,37 @@ def symbolic_mul(pa: Poly, pb: Poly) -> Poly:
     return pa * pb
 
 
-# Triple of bilinear-FF primitives, packaged for
-# :func:`symbolic_executor.run_forking`'s ``arithmetic_ops`` hook
-# (issue #68 S3). ``symbolic_sub`` returns ``pb - pa`` to match the
-# FF dispatch order (``va`` is top, ``vb`` is stack[SP-1]); the
-# forking executor's internal order is ``a - b`` where ``a`` is
-# stack[SP-1] and ``b`` is top, so we bind ``sub=lambda a, b:
-# symbolic_sub(b, a)`` to keep the two orders aligned.
+def symbolic_div_s(pa: Poly, pb: Poly) -> RationalPoly:
+    """Rational form of DIV_S; corresponds to ``forward_div_s`` over :class:`Poly`.
+
+    Order matches ``forward_div_s`` (``pa`` is top, ``pb`` is stack[SP-1]):
+    returns ``RationalPoly(num=pb, denom=pa)``. Truncation to int happens
+    at :meth:`RationalPoly.eval_at` time (the boundary step).
+    """
+    return RationalPoly(num=pb, denom=pa)
+
+
+def symbolic_rem_s(pa: Poly, pb: Poly) -> SymbolicRemainder:
+    """Symbolic remainder; corresponds to ``forward_rem_s`` over :class:`Poly`.
+
+    Order matches ``forward_rem_s``. Truncation-style remainder is applied
+    at :meth:`SymbolicRemainder.eval_at` time.
+    """
+    return SymbolicRemainder(num=pb, denom=pa)
+
+
+# Arithmetic primitives packaged for :func:`symbolic_executor.run_forking`'s
+# ``arithmetic_ops`` hook (issue #68 S3; extended for DIV_S/REM_S in #75).
+# The wrappers flip arg order where needed: the forking executor's convention
+# is ``op(a, b)`` with ``a`` = stack[SP-1] and ``b`` = top. ``symbolic_sub`` /
+# ``symbolic_div_s`` / ``symbolic_rem_s`` are written in the FF ``(pa, pb)``
+# order where ``pa`` = top, ``pb`` = SP-1, so we call them with ``(b, a)``.
 FF_ARITHMETIC_OPS = ArithmeticOps(
     add=lambda a, b: symbolic_add(a, b),
     sub=lambda a, b: symbolic_sub(b, a),
     mul=lambda a, b: symbolic_mul(a, b),
+    div_s=lambda a, b: symbolic_div_s(b, a),
+    rem_s=lambda a, b: symbolic_rem_s(b, a),
 )
 
 
@@ -274,6 +384,7 @@ FF_ARITHMETIC_OPS = ArithmeticOps(
 _SCOPE_OPS = {
     isa.OP_PUSH, isa.OP_POP, isa.OP_DUP, isa.OP_HALT, isa.OP_NOP,
     isa.OP_ADD, isa.OP_SUB, isa.OP_MUL,
+    isa.OP_DIV_S, isa.OP_REM_S,
     isa.OP_SWAP, isa.OP_OVER, isa.OP_ROT,
 }
 
@@ -282,14 +393,17 @@ _SCOPE_OPS = {
 class SymbolicForwardResult:
     """Outcome of :meth:`CompiledModel.forward_symbolic`.
 
-    ``top`` is the :class:`Poly` left on top of the symbolic stack at HALT.
-    ``stack`` is the full final stack (bottom at index 0). ``n_heads`` is
-    the number of non-NOP, non-HALT instructions executed — the "k heads"
-    matching :class:`symbolic_executor.SymbolicResult.n_heads`. ``bindings``
+    ``top`` is the value left on top of the symbolic stack at HALT — a
+    :class:`Poly` for the arithmetic fragment, a :class:`RationalPoly`
+    when the last op is DIV_S, or a :class:`SymbolicRemainder` when the
+    last op is REM_S (issue #75). ``stack`` is the full final stack
+    (bottom at index 0). ``n_heads`` is the number of non-NOP, non-HALT
+    instructions executed — the "k heads" matching
+    :class:`symbolic_executor.SymbolicResult.n_heads`. ``bindings``
     records which variable id corresponds to which PUSH constant.
     """
-    top: Poly
-    stack: List[Poly]
+    top: RationalStackValue
+    stack: List[RationalStackValue]
     n_heads: int
     bindings: Dict[int, int]
 
@@ -298,28 +412,37 @@ def evaluate_program(prog) -> SymbolicForwardResult:
     """Run ``prog`` through the bilinear FF interpreters over :class:`Poly`.
 
     Matches :func:`symbolic_executor.run_symbolic` semantically: branchless
-    straight-line programs only, one variable per PUSH, ADD/SUB/MUL delegated
-    to the symbolic primitives above. The point of duplicating the driver is
-    to make the bilinear dispatch story explicit — every arithmetic call
-    site here is the :class:`Poly` interpretation of one of the three
-    weight matrices.
+    straight-line programs only, one variable per PUSH, arithmetic delegated
+    to this module's symbolic primitives. The point of duplicating the
+    driver is to make the weight-level dispatch story explicit — every
+    arithmetic call site here is the :class:`Poly` interpretation of one
+    of the FF weight matrices (or, for DIV_S / REM_S, the rational-pair
+    form carried by :class:`RationalPoly` / :class:`SymbolicRemainder`).
     """
-    stack: List[Poly] = []
+    stack: List[RationalStackValue] = []
     bindings: Dict[int, int] = {}
     next_var = 0
     n_heads = 0
 
-    def _pop() -> Poly:
+    def _pop() -> RationalStackValue:
         if not stack:
             raise IndexError("symbolic stack underflow")
         return stack.pop()
+
+    def _require_poly(v: RationalStackValue, op_name: str) -> Poly:
+        if not isinstance(v, Poly):
+            raise BlockedOpcodeForSymbolic(
+                f"{op_name} on rational stack entries is out of scope "
+                f"(composition past one DIV_S/REM_S is a follow-up)"
+            )
+        return v
 
     for instr in prog:
         op = instr.op
         if op not in _SCOPE_OPS:
             raise BlockedOpcodeForSymbolic(
                 f"op {isa.OP_NAMES.get(op, f'?{op}')!r} is out of scope for the "
-                f"bilinear FF dispatch (ADD/SUB/MUL + stack manip only)"
+                f"bilinear FF dispatch (ADD/SUB/MUL/DIV_S/REM_S + stack manip only)"
             )
         if op == isa.OP_HALT:
             break
@@ -338,14 +461,22 @@ def evaluate_program(prog) -> SymbolicForwardResult:
                 raise IndexError("dup on empty stack")
             stack.append(stack[-1])
         elif op == isa.OP_ADD:
-            b = _pop(); a = _pop()
+            b = _require_poly(_pop(), "ADD"); a = _require_poly(_pop(), "ADD")
             stack.append(symbolic_add(a, b))
         elif op == isa.OP_SUB:
-            b = _pop(); a = _pop()
+            b = _require_poly(_pop(), "SUB"); a = _require_poly(_pop(), "SUB")
             stack.append(symbolic_sub(a, b))
         elif op == isa.OP_MUL:
-            b = _pop(); a = _pop()
+            b = _require_poly(_pop(), "MUL"); a = _require_poly(_pop(), "MUL")
             stack.append(symbolic_mul(a, b))
+        elif op == isa.OP_DIV_S:
+            b = _require_poly(_pop(), "DIV_S"); a = _require_poly(_pop(), "DIV_S")
+            # forking executor convention: a = SP-1, b = top; result = a / b.
+            # symbolic_div_s uses (pa=top, pb=SP-1) ordering.
+            stack.append(symbolic_div_s(b, a))
+        elif op == isa.OP_REM_S:
+            b = _require_poly(_pop(), "REM_S"); a = _require_poly(_pop(), "REM_S")
+            stack.append(symbolic_rem_s(b, a))
         elif op == isa.OP_SWAP:
             if len(stack) < 2:
                 raise IndexError("swap needs 2 entries")
@@ -362,7 +493,7 @@ def evaluate_program(prog) -> SymbolicForwardResult:
         else:  # pragma: no cover — guarded by _SCOPE_OPS above
             raise BlockedOpcodeForSymbolic(f"unreachable: op {op}")
 
-    top = stack[-1] if stack else Poly.constant(0)
+    top: RationalStackValue = stack[-1] if stack else Poly.constant(0)
     return SymbolicForwardResult(top=top, stack=list(stack),
                                  n_heads=n_heads, bindings=bindings)
 
@@ -396,10 +527,12 @@ __all__ = [
     "RangeCheckFailure",
     "I32_MIN", "I32_MAX",
     "E", "E_inv",
-    "M_ADD", "M_SUB", "B_MUL",
+    "M_ADD", "M_SUB", "B_MUL", "M_DIV_S", "M_REM_S",
     "n_parameters",
     "forward_add", "forward_sub", "forward_mul",
+    "forward_div_s", "forward_rem_s",
     "symbolic_add", "symbolic_sub", "symbolic_mul",
+    "symbolic_div_s", "symbolic_rem_s",
     "FF_ARITHMETIC_OPS",
     "SymbolicForwardResult",
     "evaluate_program",

--- a/ff_symbolic.py
+++ b/ff_symbolic.py
@@ -240,9 +240,11 @@ M_REM_S: torch.Tensor = _M_REM_S_matrix()
 def n_parameters(d_model: int = D_MODEL) -> int:
     """Parameter count contributed by the analytically-set FF weights.
 
-    Counts non-zero entries: 2 (M_ADD) + 2 (M_SUB) + 1 (B_MUL) + 2 (M_DIV_S)
-    + 2 (M_REM_S) = 9. The stored tensors are larger but the analytically-set
-    content is nine bits. Pre-#75 the count was 3 (ADD/SUB/MUL only).
+    Counts non-zero entries across all five matrices:
+    2 (M_ADD) + 2 (M_SUB) + 1 (B_MUL) + 2 (M_DIV_S) + 2 (M_REM_S) = 9.
+    The stored tensors are larger but the analytically-set content is nine
+    bits. Issue #69 shipped with the first three (for 5 non-zeros); issue
+    #75 added M_DIV_S / M_REM_S.
     """
     return 9
 

--- a/symbolic_executor.py
+++ b/symbolic_executor.py
@@ -567,12 +567,27 @@ def run_symbolic(prog: List[isa.Instruction]) -> SymbolicResult:
             stack.append(stack[-1])
         elif op == isa.OP_ADD:
             b = _pop(); a = _pop()
+            if not isinstance(a, Poly) or not isinstance(b, Poly):
+                raise SymbolicOpNotSupported(
+                    "ADD on rational stack entries is out of scope "
+                    "(composition past one DIV_S/REM_S is a follow-up)"
+                )
             stack.append(a + b)
         elif op == isa.OP_SUB:
             b = _pop(); a = _pop()
+            if not isinstance(a, Poly) or not isinstance(b, Poly):
+                raise SymbolicOpNotSupported(
+                    "SUB on rational stack entries is out of scope "
+                    "(composition past one DIV_S/REM_S is a follow-up)"
+                )
             stack.append(a - b)
         elif op == isa.OP_MUL:
             b = _pop(); a = _pop()
+            if not isinstance(a, Poly) or not isinstance(b, Poly):
+                raise SymbolicOpNotSupported(
+                    "MUL on rational stack entries is out of scope "
+                    "(composition past one DIV_S/REM_S is a follow-up)"
+                )
             stack.append(a * b)
         elif op == isa.OP_DIV_S:
             b = _pop(); a = _pop()
@@ -1013,12 +1028,27 @@ def _apply_poly_op(path: _Path, instr: isa.Instruction,
         stack.append(stack[-1])
     elif op == isa.OP_ADD:
         b = _pop(); a = _pop()
+        if not isinstance(a, Poly) or not isinstance(b, Poly):
+            raise SymbolicOpNotSupported(
+                "ADD on rational stack entries is out of scope "
+                "(composition past one DIV_S/REM_S is a follow-up)"
+            )
         stack.append(arithmetic_ops.add(a, b))
     elif op == isa.OP_SUB:
         b = _pop(); a = _pop()
+        if not isinstance(a, Poly) or not isinstance(b, Poly):
+            raise SymbolicOpNotSupported(
+                "SUB on rational stack entries is out of scope "
+                "(composition past one DIV_S/REM_S is a follow-up)"
+            )
         stack.append(arithmetic_ops.sub(a, b))
     elif op == isa.OP_MUL:
         b = _pop(); a = _pop()
+        if not isinstance(a, Poly) or not isinstance(b, Poly):
+            raise SymbolicOpNotSupported(
+                "MUL on rational stack entries is out of scope "
+                "(composition past one DIV_S/REM_S is a follow-up)"
+            )
         stack.append(arithmetic_ops.mul(a, b))
     elif op == isa.OP_DIV_S:
         b = _pop(); a = _pop()

--- a/symbolic_executor.py
+++ b/symbolic_executor.py
@@ -235,6 +235,102 @@ class Poly:
         return out
 
 
+# ─── Rational + remainder forms (issue #75) ───────────────────────
+#
+# DIV_S / REM_S break out of the polynomial ring: integer division is
+# not polynomial, and even the underlying rational a/b lands outside
+# :class:`Poly` without coefficient generalisation. Per the issue's
+# design note ("Probably the latter, since WASM i32.div_s is truncating
+# and we can model the rational inside the ring while the i32 rounding
+# lives at the boundary"), we keep the symbolic form rational and apply
+# ``trunc_div`` / ``trunc_rem`` only at ``eval_at`` — the same boundary
+# pattern :func:`ff_symbolic.range_check` uses for i32 wrap on ADD/SUB/MUL.
+#
+# Two minimal types, one per op: :class:`RationalPoly` for DIV_S and
+# :class:`SymbolicRemainder` for REM_S. Algebra past the op itself is
+# deliberately not closed — the catalog rows this unblocks
+# (``native_divmod``, ``native_remainder``) consist of ``PUSH b; PUSH a;
+# DIV_S/REM_S; HALT``, so no composition with Poly arithmetic is
+# required. Composing DIV_S with further ADD/SUB/MUL would need a full
+# rational-function algebra, listed as a follow-up (the issue's
+# non-goal list calls this out explicitly).
+
+
+@dataclass(frozen=True)
+class RationalPoly:
+    """Symbolic quotient ``num / denom`` under WASM ``i32.div_s`` semantics.
+
+    Stores the two operand polynomials verbatim. ``eval_at`` reduces
+    them to integers under the given bindings and then applies
+    truncating-toward-zero division (:func:`isa._trunc_div`) — the same
+    semantic the compiled transformer's nonlinear path applies. Trapping
+    on ``denom == 0`` is the caller's responsibility at the bindings
+    site; ``eval_at`` raises :class:`ZeroDivisionError` in that case.
+
+    Structural equality is value-based on ``(num, denom)``, so two
+    symbolic executors that emit the same operand polys produce equal
+    tops — the equivalence test the issue asks for.
+    """
+    num: Poly
+    denom: Poly
+
+    def variables(self) -> List[int]:
+        return sorted(set(self.num.variables()) | set(self.denom.variables()))
+
+    def eval_at(self, bindings: Mapping[int, int]) -> int:
+        """Integer result: ``trunc(num(bindings) / denom(bindings))``.
+
+        ``denom`` evaluating to 0 raises :class:`ZeroDivisionError` — the
+        catalog's `native_divmod(0, b)` variants already produce a trap
+        in :class:`executor.NumPyExecutor` rather than a value, so the
+        symbolic side mirrors that failure mode.
+        """
+        n = self.num.eval_at(bindings)
+        d = self.denom.eval_at(bindings)
+        if d == 0:
+            raise ZeroDivisionError(
+                f"RationalPoly.eval_at: denom {self.denom!r} = 0 at bindings={dict(bindings)}"
+            )
+        return _trunc_div(int(n), int(d))
+
+    def __repr__(self) -> str:
+        return f"({self.num}) /ₜ ({self.denom})"
+
+
+@dataclass(frozen=True)
+class SymbolicRemainder:
+    """Symbolic remainder ``num % denom`` under WASM ``i32.rem_s`` semantics.
+
+    Stored as a ``(num, denom)`` pair rather than reduced to a closed
+    polynomial form, because ``b mod a`` is not rational in ``(a, b)``
+    — the truncation that defines it is piecewise, not algebraic.
+    ``eval_at`` applies :func:`isa._trunc_rem` at the boundary, matching
+    the compiled transformer.
+    """
+    num: Poly
+    denom: Poly
+
+    def variables(self) -> List[int]:
+        return sorted(set(self.num.variables()) | set(self.denom.variables()))
+
+    def eval_at(self, bindings: Mapping[int, int]) -> int:
+        n = self.num.eval_at(bindings)
+        d = self.denom.eval_at(bindings)
+        if d == 0:
+            raise ZeroDivisionError(
+                f"SymbolicRemainder.eval_at: denom {self.denom!r} = 0 at bindings={dict(bindings)}"
+            )
+        return _trunc_rem(int(n), int(d))
+
+    def __repr__(self) -> str:
+        return f"({self.num}) %ₜ ({self.denom})"
+
+
+# Union covering every "top of symbolic stack" type run_symbolic /
+# run_forking might emit for a branchless polynomial-plus-rational program.
+RationalStackValue = Union[Poly, RationalPoly, SymbolicRemainder]
+
+
 # ─── Guard + GuardedPoly ──────────────────────────────────────────
 #
 # A guard is a polynomial we assert is either "== 0" or "!= 0". A
@@ -347,9 +443,14 @@ class GuardedPoly:
 
 # Opcodes the *branchless* fragment understands — preserved for the
 # legacy run_symbolic entry point that the original PoC tests exercise.
+# Issue #75 adds DIV_S / REM_S: they break the polynomial-ring closure
+# (outputs are :class:`RationalPoly` / :class:`SymbolicRemainder`) but
+# the executor still accepts them as long as nothing downstream tries to
+# compose a Poly op against a rational stack entry.
 _POLY_OPS = {
     isa.OP_PUSH, isa.OP_POP, isa.OP_DUP, isa.OP_HALT,
     isa.OP_ADD, isa.OP_SUB, isa.OP_MUL,
+    isa.OP_DIV_S, isa.OP_REM_S,
     isa.OP_SWAP, isa.OP_OVER, isa.OP_ROT, isa.OP_NOP,
 }
 # Branch ops the forking executor additionally handles.
@@ -362,15 +463,18 @@ _FORKING_OPS = _POLY_OPS | _BRANCH_OPS
 class SymbolicResult:
     """Outcome of running a program symbolically.
 
-    ``top`` is the polynomial left on top of the stack after HALT (or at
-    the end of the trace if HALT is absent). ``stack`` is the full final
-    stack (bottom at index 0). ``n_heads`` is the number of instructions
-    executed — the "k heads" the issue talks about. ``bindings`` maps the
-    allocated variable indices back to the original PUSH constants.
+    ``top`` is the top-of-stack value after HALT (or at the end of the
+    trace if HALT is absent). For the ADD/SUB/MUL fragment it's a
+    :class:`Poly`; for the DIV_S / REM_S rows added in issue #75 it can
+    also be :class:`RationalPoly` or :class:`SymbolicRemainder`. ``stack``
+    is the full final stack (bottom at index 0). ``n_heads`` is the
+    number of instructions executed — the "k heads" the issue talks
+    about. ``bindings`` maps the allocated variable indices back to the
+    original PUSH constants.
     """
 
-    top: Poly
-    stack: List[Poly]
+    top: RationalStackValue
+    stack: List[RationalStackValue]
     n_heads: int
     bindings: Dict[int, int]
 
@@ -378,10 +482,18 @@ class SymbolicResult:
         """k_heads ÷ n_monomials in the top expression, after simplification.
 
         Matches the issue's "9 heads → 1 monomial" style report. Returns
-        `inf` when the top collapses to zero (no monomials) — flagged by
-        callers who want a cleaner representation.
+        ``inf`` when the top collapses to zero (no monomials) — flagged
+        by callers who want a cleaner representation. For rational
+        outputs (DIV_S / REM_S) the denominator counts as an additional
+        monomial bundle; we sum the two sides' monomial counts to keep
+        the "one number" shape of the ratio.
         """
-        n = self.top.n_monomials()
+        if isinstance(self.top, Poly):
+            n = self.top.n_monomials()
+        elif isinstance(self.top, (RationalPoly, SymbolicRemainder)):
+            n = self.top.num.n_monomials() + self.top.denom.n_monomials()
+        else:
+            return float("inf")
         if n == 0:
             return float("inf")
         return self.n_heads / n
@@ -462,6 +574,22 @@ def run_symbolic(prog: List[isa.Instruction]) -> SymbolicResult:
         elif op == isa.OP_MUL:
             b = _pop(); a = _pop()
             stack.append(a * b)
+        elif op == isa.OP_DIV_S:
+            b = _pop(); a = _pop()
+            if not isinstance(a, Poly) or not isinstance(b, Poly):
+                raise SymbolicOpNotSupported(
+                    "DIV_S on rational stack entries is out of scope "
+                    "(composition past one DIV_S/REM_S is a follow-up)"
+                )
+            stack.append(RationalPoly(num=a, denom=b))
+        elif op == isa.OP_REM_S:
+            b = _pop(); a = _pop()
+            if not isinstance(a, Poly) or not isinstance(b, Poly):
+                raise SymbolicOpNotSupported(
+                    "REM_S on rational stack entries is out of scope "
+                    "(composition past one DIV_S/REM_S is a follow-up)"
+                )
+            stack.append(SymbolicRemainder(num=a, denom=b))
         elif op == isa.OP_SWAP:
             if len(stack) < 2:
                 raise SymbolicStackUnderflow("swap needs 2 entries")
@@ -500,25 +628,38 @@ def run_symbolic(prog: List[isa.Instruction]) -> SymbolicResult:
 
 
 ArithFn = Callable[["Poly", "Poly"], "Poly"]
+DivFn = Callable[["Poly", "Poly"], "RationalPoly"]
+RemFn = Callable[["Poly", "Poly"], "SymbolicRemainder"]
 
 
 @dataclass(frozen=True)
 class ArithmeticOps:
-    """Three-operator spec the forking executor consumes for ADD/SUB/MUL.
+    """Operator spec the forking executor consumes for the arithmetic
+    fragment of the ISA.
 
     ``sub(a, b)`` must return ``a - b`` (executor computes ``a - b``
     where ``a`` is the second-from-top, matching the existing Poly
     order). ``ff_symbolic.symbolic_sub`` matches this spec.
+
+    ``div_s(a, b)`` / ``rem_s(a, b)`` (issue #75) must return the
+    symbolic quotient / remainder of ``a / b`` under WASM
+    ``i32.div_s`` / ``i32.rem_s`` semantics — ``a`` is stack[SP-1] (the
+    dividend) and ``b`` is top (the divisor), matching the numeric
+    path's ``_trunc_div(vb, va)`` convention (``executor.py:835-838``).
     """
     add: ArithFn
     sub: ArithFn
     mul: ArithFn
+    div_s: DivFn = None  # type: ignore[assignment]
+    rem_s: RemFn = None  # type: ignore[assignment]
 
 
 DEFAULT_ARITHMETIC_OPS = ArithmeticOps(
     add=lambda a, b: a + b,
     sub=lambda a, b: a - b,
     mul=lambda a, b: a * b,
+    div_s=lambda a, b: RationalPoly(num=a, denom=b),
+    rem_s=lambda a, b: SymbolicRemainder(num=a, denom=b),
 )
 
 
@@ -530,8 +671,17 @@ DEFAULT_MAX_PATHS = 64
 DEFAULT_MAX_STEPS = 50_000
 
 
-def _as_concrete_int(p: Poly) -> Optional[int]:
-    """Return integer value if ``p`` has no variables; else None."""
+def _as_concrete_int(p: "RationalStackValue") -> Optional[int]:
+    """Return integer value if ``p`` has no variables; else None.
+
+    Rational stack values (``RationalPoly`` / ``SymbolicRemainder``) never
+    collapse to a concrete int for branching purposes — DIV_S/REM_S past a
+    subsequent JZ/JNZ is out of scope for issue #75, so return ``None``
+    and let the caller fall into the symbolic-cond path (which will then
+    raise when it tries to wrap the value in a Guard).
+    """
+    if not isinstance(p, Poly):
+        return None
     if not p.terms:
         return 0
     if len(p.terms) == 1 and () in p.terms:
@@ -557,13 +707,13 @@ class _Path:
     static sites get distinct ids even across paths.
     """
     pc: int
-    stack: Tuple[Poly, ...]
+    stack: Tuple["RationalStackValue", ...]
     guards: Tuple[Guard, ...]
     bindings: Dict[int, int]
     n_heads: int = 0
     visited_branches: frozenset = field(default_factory=frozenset)
     loop_unrolled: bool = False  # True if this path ever took a back-edge
-    halted_top: Optional[Poly] = None
+    halted_top: Optional["RationalStackValue"] = None
 
     def with_(self, **kwargs) -> "_Path":
         """Return a copy with selected fields replaced."""
@@ -834,17 +984,18 @@ def run_forking(prog: List[isa.Instruction], *,
 
 def _apply_poly_op(path: _Path, instr: isa.Instruction,
                    input_mode: str,
-                   arithmetic_ops: ArithmeticOps = DEFAULT_ARITHMETIC_OPS) -> Tuple[Poly, ...]:
+                   arithmetic_ops: ArithmeticOps = DEFAULT_ARITHMETIC_OPS) -> Tuple[RationalStackValue, ...]:
     """Apply a non-branch opcode to ``path.stack`` and return the new stack.
 
-    ``arithmetic_ops`` picks the ADD/SUB/MUL implementations. Defaults to
-    Poly's native operators; :mod:`ff_symbolic` passes its bilinear-FF
+    ``arithmetic_ops`` picks the ADD/SUB/MUL/DIV_S/REM_S implementations.
+    Defaults to Poly's native operators (plus RationalPoly/SymbolicRemainder
+    wrappers for DIV_S/REM_S); :mod:`ff_symbolic` passes its bilinear-FF
     primitives.
     """
     op = instr.op
     stack = list(path.stack)
 
-    def _pop() -> Poly:
+    def _pop() -> RationalStackValue:
         if not stack:
             raise SymbolicStackUnderflow(f"pop from empty stack at pc={path.pc}")
         return stack.pop()
@@ -869,6 +1020,30 @@ def _apply_poly_op(path: _Path, instr: isa.Instruction,
     elif op == isa.OP_MUL:
         b = _pop(); a = _pop()
         stack.append(arithmetic_ops.mul(a, b))
+    elif op == isa.OP_DIV_S:
+        b = _pop(); a = _pop()
+        if not isinstance(a, Poly) or not isinstance(b, Poly):
+            raise SymbolicOpNotSupported(
+                "DIV_S on rational stack entries is out of scope "
+                "(composition past one DIV_S/REM_S is a follow-up)"
+            )
+        if arithmetic_ops.div_s is None:
+            raise SymbolicOpNotSupported(
+                "arithmetic_ops.div_s is not wired; pass a div_s primitive"
+            )
+        stack.append(arithmetic_ops.div_s(a, b))
+    elif op == isa.OP_REM_S:
+        b = _pop(); a = _pop()
+        if not isinstance(a, Poly) or not isinstance(b, Poly):
+            raise SymbolicOpNotSupported(
+                "REM_S on rational stack entries is out of scope "
+                "(composition past one DIV_S/REM_S is a follow-up)"
+            )
+        if arithmetic_ops.rem_s is None:
+            raise SymbolicOpNotSupported(
+                "arithmetic_ops.rem_s is not wired; pass a rem_s primitive"
+            )
+        stack.append(arithmetic_ops.rem_s(a, b))
     elif op == isa.OP_SWAP:
         if len(stack) < 2:
             raise SymbolicStackUnderflow(f"swap needs 2 entries at pc={path.pc}")

--- a/symbolic_executor.py
+++ b/symbolic_executor.py
@@ -40,21 +40,47 @@ Out of scope (file as follow-ups):
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from fractions import Fraction
 from typing import Callable, Dict, List, Mapping, Optional, Tuple, Union
 
 import isa
+from isa import _trunc_div, _trunc_rem
 
 
 # ─── Poly ──────────────────────────────────────────────────────────
 #
-# Polynomial over integer-indexed symbolic variables with integer
-# coefficients. Canonical form: terms is a dict keyed by a monomial
-# (tuple of (var_idx, power) pairs, sorted by var_idx, powers > 0).
-# The empty tuple `()` is the constant monomial. Zero-coefficient
-# terms are dropped on construction so comparisons are value-equal
-# when the polynomials are mathematically equal.
+# Polynomial over integer-indexed symbolic variables with rational
+# (``int`` or :class:`fractions.Fraction`) coefficients. Canonical form:
+# ``terms`` is a dict keyed by a monomial (tuple of (var_idx, power)
+# pairs, sorted by var_idx, powers > 0). The empty tuple ``()`` is the
+# constant monomial. Zero-coefficient terms are dropped on construction
+# so comparisons are value-equal when the polynomials are mathematically
+# equal.
+#
+# Rational coefficients land via issue #75 (symbolic DIV_S / REM_S): the
+# bilinear forms for ADD/SUB/MUL produce polynomials over ℤ, but DIV_S
+# introduces rational polynomials (``a/b`` with integer ``a, b``). To keep
+# one canonical type, coefficients accept ``int | Fraction`` and
+# normalise to ``int`` whenever the denominator is 1 — so every Poly
+# produced by ADD/SUB/MUL still has literal ``int`` coefficients and
+# existing structural-equality tests remain green.
 
 Monomial = Tuple[Tuple[int, int], ...]
+
+
+def _norm_coeff(c):
+    """Normalise a coefficient to ``int`` when integral, else ``Fraction``.
+
+    Accepts ``int`` or ``Fraction`` input. The canonical form keeps
+    integer coefficients as ``int`` so value-compare against the
+    pre-#75 Polys still works and ``repr`` output stays unchanged for
+    the ADD/SUB/MUL fragment.
+    """
+    if isinstance(c, Fraction):
+        if c.denominator == 1:
+            return int(c.numerator)
+        return c
+    return int(c)
 
 
 def _mono_mul(a: Monomial, b: Monomial) -> Monomial:
@@ -82,17 +108,20 @@ def _mono_str(mono: Monomial) -> str:
 
 @dataclass(frozen=True)
 class Poly:
-    """Multivariate polynomial with integer coefficients.
+    """Multivariate polynomial with rational coefficients.
 
-    `terms` maps a monomial (canonical-form tuple) to its coefficient.
-    Zero-coefficient entries are never stored.
+    ``terms`` maps a monomial (canonical-form tuple) to its coefficient,
+    which is ``int`` when the coefficient is integral and
+    :class:`fractions.Fraction` when the denominator is >1. Zero-
+    coefficient entries are never stored.
     """
 
-    terms: Mapping[Monomial, int]
+    terms: Mapping[Monomial, Union[int, Fraction]]
 
     @staticmethod
-    def _normalise(terms: Mapping[Monomial, int]) -> Dict[Monomial, int]:
-        return {m: int(c) for m, c in terms.items() if c != 0}
+    def _normalise(terms: Mapping[Monomial, Union[int, Fraction]]
+                   ) -> Dict[Monomial, Union[int, Fraction]]:
+        return {m: _norm_coeff(c) for m, c in terms.items() if c != 0}
 
     def __post_init__(self):
         # Freeze a normalised copy. Doing it this way so callers can pass
@@ -102,10 +131,10 @@ class Poly:
     # ── Constructors ──────────────────────────────────────────
 
     @classmethod
-    def constant(cls, c: int) -> "Poly":
+    def constant(cls, c: Union[int, Fraction]) -> "Poly":
         if c == 0:
             return cls({})
-        return cls({(): int(c)})
+        return cls({(): _norm_coeff(c)})
 
     @classmethod
     def variable(cls, idx: int) -> "Poly":
@@ -149,19 +178,22 @@ class Poly:
                 seen.add(v)
         return sorted(seen)
 
-    def eval_at(self, bindings: Mapping[int, int]) -> int:
-        """Substitute `bindings[i]` for each ``x_i`` and reduce to an int.
+    def eval_at(self, bindings: Mapping[int, int]) -> Union[int, Fraction]:
+        """Substitute ``bindings[i]`` for each ``x_i`` and reduce.
 
-        Missing variables raise KeyError — symbolic executors that emit
-        a variable per PUSH should pass one binding per PUSH.
+        Returns ``int`` when the result is integral (the common case for
+        ADD/SUB/MUL Polys), otherwise returns :class:`fractions.Fraction`
+        (after a DIV_S introduces a rational coefficient). Missing
+        variables raise ``KeyError`` — symbolic executors that emit a
+        variable per PUSH should pass one binding per PUSH.
         """
-        total = 0
+        total: Union[int, Fraction] = 0
         for mono, coeff in self.terms.items():
-            term = coeff
+            term: Union[int, Fraction] = coeff
             for v, p in mono:
                 term *= bindings[v] ** p
             total += term
-        return int(total)
+        return _norm_coeff(total)
 
     # ── Equality / display ────────────────────────────────────
 

--- a/symbolic_programs_catalog.py
+++ b/symbolic_programs_catalog.py
@@ -40,7 +40,9 @@ from symbolic_executor import (
     Guard,
     GuardedPoly,
     Poly,
+    RationalPoly,
     SymbolicOpNotSupported,
+    SymbolicRemainder,
     SymbolicStackUnderflow,
     run_forking,
     run_symbolic,
@@ -100,6 +102,7 @@ def poly_to_expr(poly: Poly, var_prefix: str = "x") -> str:
 _POLY_OPS = {
     isa.OP_PUSH, isa.OP_POP, isa.OP_DUP, isa.OP_HALT,
     isa.OP_ADD, isa.OP_SUB, isa.OP_MUL,
+    isa.OP_DIV_S, isa.OP_REM_S,
     isa.OP_SWAP, isa.OP_OVER, isa.OP_ROT, isa.OP_NOP,
 }
 # Control flow — handled by the forking executor (issue #70).
@@ -124,6 +127,9 @@ class ClassificationResult:
     blocker: Optional[str] = None
     poly: Optional[Poly] = None           # present when status == collapsed*
     guarded: Optional[GuardedPoly] = None # present when status == collapsed_guarded
+    # Rational tops (issue #75) — present when the program ends on a single
+    # DIV_S (RationalPoly) or REM_S (SymbolicRemainder).
+    rational: Optional[Any] = None        # Union[RationalPoly, SymbolicRemainder]
     n_heads: int = 0
     bindings: Dict[int, int] = field(default_factory=dict)
     n_cases: int = 0                       # number of cases in guarded output
@@ -170,6 +176,11 @@ def classify_program(prog) -> ClassificationResult:
         return ClassificationResult(status=STATUS_BLOCKED_UNDERFLOW)
 
     if r_sym.status == "straight":
+        if isinstance(r_sym.top, (RationalPoly, SymbolicRemainder)):
+            return ClassificationResult(
+                status=STATUS_COLLAPSED, rational=r_sym.top,
+                n_heads=r_sym.n_heads, bindings=dict(r_sym.bindings),
+            )
         top = r_sym.top if isinstance(r_sym.top, Poly) else None
         return ClassificationResult(
             status=STATUS_COLLAPSED, poly=top,
@@ -282,8 +293,11 @@ def _default_catalog() -> List[CatalogEntry]:
         expected=20,
     ))
 
-    # Blocked — non-polynomial opcodes
+    # Rational tops (issue #75) — collapse to RationalPoly / SymbolicRemainder.
     entries.append(CatalogEntry("native_divmod(2,7)",   *P.make_native_divmod(2, 7)))
+    entries.append(CatalogEntry("native_remainder(2,7)", *P.make_native_remainder(2, 7)))
+
+    # Blocked — non-polynomial opcodes
     entries.append(CatalogEntry("native_clz(16)",       *P.make_native_clz(16)))
     entries.append(CatalogEntry("native_abs_unary(-3)", *P.make_native_abs_unary(-3)))
     entries.append(CatalogEntry("native_neg(5)",        *P.make_native_neg(5)))
@@ -350,6 +364,11 @@ class CatalogRow:
     eml_guard_size: Optional[int] = None     # sum of guard-poly sizes across every case
     eml_guard_depth: Optional[int] = None    # max guard-poly depth across every case
     case_eml: Optional[List[GuardedCaseEML]] = None
+    # Rational top flag (issue #75) — True for programs that collapse to
+    # a RationalPoly / SymbolicRemainder rather than a pure Poly. eml_* /
+    # n_monomials fields stay ``None`` for these rows since eml-sr has no
+    # division primitive; ``poly_expr`` renders the rational form.
+    is_rational: bool = False
 
 
 def _numpy_top(np_exec: NumPyExecutor, prog) -> Optional[int]:
@@ -420,7 +439,9 @@ def run_catalog(entries: Optional[List[CatalogEntry]] = None, *,
         row.numpy_top = _numpy_top(np_exec, entry.prog)
 
         if cr.status == STATUS_COLLAPSED or cr.status == STATUS_COLLAPSED_UNROLLED:
-            if cr.poly is not None:
+            if cr.rational is not None:
+                _fill_rational_row(row, cr.rational, cr.bindings, row.numpy_top)
+            elif cr.poly is not None:
                 _fill_poly_row(row, cr.poly, cr.bindings, row.numpy_top)
             elif cr.guarded is not None:
                 # Unrolled + guarded (rare) — fall through to guarded formatter
@@ -451,6 +472,37 @@ def _fill_poly_row(row: CatalogRow, poly: Poly,
                         if v in bindings}
         eml_val = eval_eml(tree, eml_bindings) if eml_bindings or not poly.variables() else None
     row.numeric_match = _three_way_numeric_match(numpy_top, sym_val, eml_val)
+
+
+def _fill_rational_row(row: CatalogRow, rational,
+                       bindings: Dict[int, int],
+                       numpy_top: Optional[int]) -> None:
+    """Populate a CatalogRow from a rational top (issue #75).
+
+    ``rational`` is a :class:`RationalPoly` (DIV_S) or
+    :class:`SymbolicRemainder` (REM_S). Renders as ``"num /ₜ denom"`` /
+    ``"num modₜ denom"``; evaluates via the wrapper's ``eval_at`` so
+    truncation toward zero (WASM ``i32.div_s`` / ``i32.rem_s`` semantics)
+    is applied at the boundary. eml-sr columns stay ``None`` — elementary
+    expressions in the single ``eml(x, y) = exp(x) - ln(y)`` operator
+    have no division primitive.
+    """
+    row.is_rational = True
+    row.poly_expr = repr(rational)
+    # n_monomials summarises the expression complexity: sum of the two
+    # underlying Polys' term counts, giving a meaningful size proxy even
+    # without an EML tree.
+    row.n_monomials = rational.num.n_monomials() + rational.denom.n_monomials()
+
+    try:
+        sym_val = rational.eval_at(bindings) if bindings else rational.eval_at({})
+    except (KeyError, ValueError, ZeroDivisionError):
+        sym_val = None
+
+    if sym_val is None or numpy_top is None:
+        row.numeric_match = None
+    else:
+        row.numeric_match = (sym_val == numpy_top)
 
 
 def _fill_guarded_row(row: CatalogRow, guarded: GuardedPoly,

--- a/test_ff_symbolic.py
+++ b/test_ff_symbolic.py
@@ -440,25 +440,30 @@ def test_sum_of_squares_pin():
 # ─── Blocked-opcode handling ──────────────────────────────────────
 
 def test_blocked_opcodes():
-    """Ops outside the ADD/SUB/MUL fragment raise BlockedOpcodeForSymbolic.
+    """Ops outside the fragment raise BlockedOpcodeForSymbolic.
 
-    The issue's scope is explicit: DIV_S / REM_S / comparisons / bitwise
-    are non-goals. forward_symbolic refuses them rather than returning a
-    wrong answer.
+    Post issue #75 the fragment is ADD/SUB/MUL/DIV_S/REM_S + stack manip;
+    comparisons, bitwise, control-flow-within-branchless, and arithmetic
+    composition past a rational stack entry remain non-goals.
     """
     model = CompiledModel()
 
-    # DIV_S: not polynomial-closed.
-    prog = program(("PUSH", 10), ("PUSH", 3), ("DIV_S",), ("HALT",))
+    # Arithmetic composition past a rational stack entry — DIV_S then ADD.
+    # DIV_S is in scope, but ADD on the resulting RationalPoly is not.
+    prog = program(
+        ("PUSH", 10), ("PUSH", 3), ("DIV_S",),
+        ("PUSH", 1), ("ADD",), ("HALT",),
+    )
     try:
         model.forward_symbolic(prog)
-        _fail("blocked[DIV_S]", "expected BlockedOpcodeForSymbolic")
+        _fail("blocked[compose-past-DIV_S]", "expected BlockedOpcodeForSymbolic")
     except ff.BlockedOpcodeForSymbolic:
-        _pass("blocked[DIV_S]")
+        _pass("blocked[compose-past-DIV_S]")
     except Exception as e:
-        _fail("blocked[DIV_S]", f"wrong exception: {type(e).__name__}: {e}")
+        _fail("blocked[compose-past-DIV_S]",
+              f"wrong exception: {type(e).__name__}: {e}")
 
-    # JZ: control flow, not this issue's scope.
+    # JZ: control flow, not this issue's scope (in straight-line forward).
     prog = program(("PUSH", 1), ("JZ", 10), ("HALT",))
     try:
         model.forward_symbolic(prog)

--- a/test_ff_symbolic.py
+++ b/test_ff_symbolic.py
@@ -36,7 +36,14 @@ import ff_symbolic as ff
 import isa
 from executor import CompiledModel, NumPyExecutor
 from isa import DIM_VALUE, program
-from symbolic_executor import GuardedPoly, Poly, run_forking, run_symbolic
+from symbolic_executor import (
+    GuardedPoly,
+    Poly,
+    RationalPoly,
+    SymbolicRemainder,
+    run_forking,
+    run_symbolic,
+)
 from symbolic_programs_catalog import (
     STATUS_COLLAPSED,
     STATUS_COLLAPSED_GUARDED,
@@ -437,6 +444,138 @@ def test_sum_of_squares_pin():
     _check("sum_of_squares eval", fs.top.eval_at({0: 3, 1: 4}) == 25)
 
 
+# ─── Rational primitives (issue #75) ──────────────────────────────
+
+def test_primitives_div_rem_s():
+    """forward_div_s / forward_rem_s agree with Python trunc_div / trunc_rem.
+
+    Covers sign combinations and the zero-divisor check deliberately
+    skipped: the numeric path raises via ``_trunc_div`` when the divisor
+    is zero, so we only exercise non-zero divisors here.
+    """
+    samples: List[Tuple[int, int]] = [
+        # (a, b) where a is top (va), b is stack[SP-1] (vb); op computes
+        # trunc_div(vb, va), trunc_rem(vb, va) — matches WASM i32.div_s.
+        (3, 10), (-3, 10), (3, -10), (-3, -10),
+        (7, 0), (1, 2**15),
+    ]
+    for a, b in samples:
+        if a == 0:
+            continue
+        ea, eb = ff.E(a), ff.E(b)
+        expected_q = isa._trunc_div(b, a)
+        expected_r = isa._trunc_rem(b, a)
+        _check(f"forward_div_s({a},{b})",
+               ff.E_inv(ff.forward_div_s(ea, eb)) == expected_q,
+               f"got {ff.E_inv(ff.forward_div_s(ea, eb))}, expect {expected_q}")
+        _check(f"forward_rem_s({a},{b})",
+               ff.E_inv(ff.forward_rem_s(ea, eb)) == expected_r,
+               f"got {ff.E_inv(ff.forward_rem_s(ea, eb))}, expect {expected_r}")
+
+
+def test_primitives_rational_matrix_shapes():
+    """M_DIV_S / M_REM_S are pair-selectors (shape (2, 2*d_model))."""
+    d = ff.D_MODEL
+    _check("M_DIV_S shape", ff.M_DIV_S.shape == (2, 2 * d))
+    _check("M_REM_S shape", ff.M_REM_S.shape == (2, 2 * d))
+
+    # Row 0 pulls va from ea[DIM_VALUE]; row 1 pulls vb from eb[DIM_VALUE].
+    for name, W in (("M_DIV_S", ff.M_DIV_S), ("M_REM_S", ff.M_REM_S)):
+        _check(f"{name}[0, DIM_VALUE] == 1",
+               float(W[0, DIM_VALUE].item()) == 1.0)
+        _check(f"{name}[1, d+DIM_VALUE] == 1",
+               float(W[1, d + DIM_VALUE].item()) == 1.0)
+        nonzero = (W != 0).sum().item()
+        _check(f"{name} has exactly 2 nonzeros", nonzero == 2)
+
+
+def test_symbolic_rational_primitives():
+    """symbolic_div_s / rem_s return RationalPoly / SymbolicRemainder."""
+    x0, x1 = Poly.variable(0), Poly.variable(1)
+    q = ff.symbolic_div_s(x0, x1)           # pa=x0=top, pb=x1=SP-1 → x1 / x0
+    r = ff.symbolic_rem_s(x0, x1)
+    _check("symbolic_div_s returns RationalPoly", isinstance(q, RationalPoly))
+    _check("symbolic_rem_s returns SymbolicRemainder", isinstance(r, SymbolicRemainder))
+    _check("symbolic_div_s num == pb", q.num == x1, f"got {q.num!r}")
+    _check("symbolic_div_s denom == pa", q.denom == x0, f"got {q.denom!r}")
+    _check("symbolic_rem_s num == pb", r.num == x1)
+    _check("symbolic_rem_s denom == pa", r.denom == x0)
+
+
+def test_equivalence_rational():
+    """forward_symbolic on DIV_S / REM_S programs matches run_symbolic structurally.
+
+    Both interpreters carry the (num, denom) pair forward — the
+    :class:`RationalPoly` / :class:`SymbolicRemainder` wrappers — and
+    evaluating either at the catalog's bindings must match the numeric
+    ``NumPyExecutor`` top bit-for-bit.
+    """
+    model = CompiledModel()
+    np_exec = NumPyExecutor()
+
+    cases = [
+        # (name, prog) — mirrors catalog entries that now collapse. Inputs
+        # are kept non-negative so the ℤ-valued rational eval agrees with
+        # the masked u32 :class:`NumPyExecutor` top (parity at the boundary
+        # per the Option (a) range assumption from issue #69).
+        ("native_divmod(2,7)",
+         program(("PUSH", 7), ("PUSH", 2), ("DIV_S",), ("HALT",))),
+        ("native_remainder(2,7)",
+         program(("PUSH", 7), ("PUSH", 2), ("REM_S",), ("HALT",))),
+        ("native_divmod(3,10)",
+         program(("PUSH", 10), ("PUSH", 3), ("DIV_S",), ("HALT",))),
+        ("native_remainder(3,10)",
+         program(("PUSH", 10), ("PUSH", 3), ("REM_S",), ("HALT",))),
+    ]
+    for name, prog_ in cases:
+        sym_result = run_symbolic(prog_)
+        fs_result = model.forward_symbolic(prog_)
+        _check(
+            f"rational.struct[{name}]",
+            type(sym_result.top) is type(fs_result.top),
+            f"sym={type(sym_result.top).__name__}, ff={type(fs_result.top).__name__}",
+        )
+        _check(
+            f"rational.num[{name}]",
+            sym_result.top.num == fs_result.top.num,
+            f"sym.num={sym_result.top.num!r} vs ff.num={fs_result.top.num!r}",
+        )
+        _check(
+            f"rational.denom[{name}]",
+            sym_result.top.denom == fs_result.top.denom,
+            f"sym.denom={sym_result.top.denom!r} vs ff.denom={fs_result.top.denom!r}",
+        )
+        # Three-way numeric match: sym eval == ff eval == NumPy.
+        sym_val = sym_result.top.eval_at(sym_result.bindings)
+        ff_val = fs_result.top.eval_at(fs_result.bindings)
+        np_trace = np_exec.execute(prog_)
+        np_top = np_trace.steps[-1].top
+        _check(
+            f"rational.numeric[{name}]",
+            sym_val == ff_val == np_top,
+            f"sym={sym_val}, ff={ff_val}, np={np_top}",
+        )
+
+
+def test_rational_catalog_rows_classify_as_collapsed():
+    """native_divmod / native_remainder catalog entries collapse (#75)."""
+    names_of_interest = {"native_divmod(2,7)", "native_remainder(2,7)"}
+    for entry in _default_catalog():
+        if entry.name not in names_of_interest:
+            continue
+        cr = classify_program(entry.prog)
+        _check(
+            f"catalog.status[{entry.name}] == collapsed",
+            cr.status == STATUS_COLLAPSED,
+            f"got {cr.status} (blocker={cr.blocker})",
+        )
+        _check(
+            f"catalog.rational[{entry.name}] is set",
+            cr.rational is not None,
+            f"got {cr.rational!r}",
+        )
+
+
 # ─── Blocked-opcode handling ──────────────────────────────────────
 
 def test_blocked_opcodes():
@@ -496,6 +635,11 @@ def main():
         test_equivalence_unrolled_numeric,
         test_dup_add_chain_pin,
         test_sum_of_squares_pin,
+        test_primitives_div_rem_s,
+        test_primitives_rational_matrix_shapes,
+        test_symbolic_rational_primitives,
+        test_equivalence_rational,
+        test_rational_catalog_rows_classify_as_collapsed,
         test_blocked_opcodes,
     ]
     print("=" * 60)

--- a/test_symbolic_executor.py
+++ b/test_symbolic_executor.py
@@ -141,14 +141,31 @@ def test_nop_preserves_stack():
 
 
 def test_unsupported_op_raises():
-    import pytest
-    prog = program(("PUSH", 2), ("PUSH", 3), ("DIV_S",), ("HALT",))
+    # AND remains outside _POLY_OPS (bitwise — not rational-algebraic).
+    # DIV_S / REM_S are in scope per issue #75.
+    prog = program(("PUSH", 12), ("PUSH", 10), ("AND",), ("HALT",))
     try:
         run_symbolic(prog)
     except SymbolicOpNotSupported as e:
-        assert "DIV_S" in str(e)
+        assert "AND" in str(e)
     else:
-        raise AssertionError("expected SymbolicOpNotSupported for DIV_S")
+        raise AssertionError("expected SymbolicOpNotSupported for AND")
+
+
+def test_div_s_composition_raises():
+    """DIV_S then ADD — arithmetic on a RationalPoly is out of scope (#75)."""
+    prog = program(
+        ("PUSH", 10), ("PUSH", 3), ("DIV_S",),
+        ("PUSH", 1), ("ADD",), ("HALT",),
+    )
+    try:
+        run_symbolic(prog)
+    except SymbolicOpNotSupported as e:
+        assert "rational" in str(e).lower() or "DIV_S" in str(e) or "REM_S" in str(e)
+    else:
+        raise AssertionError(
+            "expected SymbolicOpNotSupported for ADD on RationalPoly"
+        )
 
 
 def test_pop_underflow_raises():

--- a/test_symbolic_programs_catalog.py
+++ b/test_symbolic_programs_catalog.py
@@ -115,7 +115,21 @@ def test_classify_guarded_on_symbolic_branch():
 
 
 def test_classify_blocks_nonpolynomial_opcode():
-    # PUSH 2, PUSH 7, DIV_S, HALT
+    # PUSH, AND: AND is outside _POLY_OPS (bitwise).
+    # DIV_S / REM_S are in scope per issue #75.
+    prog = [
+        isa.Instruction(isa.OP_PUSH, 12),
+        isa.Instruction(isa.OP_PUSH, 10),
+        isa.Instruction(isa.OP_AND),
+        isa.Instruction(isa.OP_HALT),
+    ]
+    cr = classify_program(prog)
+    assert cr.status == "blocked_opcode"
+    assert cr.blocker == "AND"
+
+
+def test_classify_rational_top_on_div_s():
+    """DIV_S at HALT now collapses to a RationalPoly (issue #75)."""
     prog = [
         isa.Instruction(isa.OP_PUSH, 2),
         isa.Instruction(isa.OP_PUSH, 7),
@@ -123,8 +137,23 @@ def test_classify_blocks_nonpolynomial_opcode():
         isa.Instruction(isa.OP_HALT),
     ]
     cr = classify_program(prog)
-    assert cr.status == "blocked_opcode"
-    assert cr.blocker == "DIV_S"
+    assert cr.status == "collapsed", cr.status
+    assert cr.rational is not None
+    assert cr.poly is None
+
+
+def test_classify_rational_top_on_rem_s():
+    """REM_S at HALT collapses to a SymbolicRemainder (issue #75)."""
+    prog = [
+        isa.Instruction(isa.OP_PUSH, 2),
+        isa.Instruction(isa.OP_PUSH, 7),
+        isa.Instruction(isa.OP_REM_S),
+        isa.Instruction(isa.OP_HALT),
+    ]
+    cr = classify_program(prog)
+    assert cr.status == "collapsed", cr.status
+    assert cr.rational is not None
+    assert cr.poly is None
 
 
 def test_classify_first_blocker_wins():


### PR DESCRIPTION
## Summary

Extends the symbolic executor and FF bilinear layer to handle `DIV_S` /
`REM_S` via a rational-form wrapper, with integer truncation applied
only at the evaluation boundary.

- `Poly` coefficients now carry `Fraction`; `RationalPoly` and
  `SymbolicRemainder` are frozen dataclasses representing a single
  truncating division / remainder at the top of the stack.
- `run_symbolic` / `run_forking` accept these rational stack values for
  terminal `DIV_S` / `REM_S`; composition past a rational entry raises
  `SymbolicOpNotSupported` (follow-up scope).
- `ff_symbolic.py` adds two pair-selector matrices `M_DIV_S` / `M_REM_S`
  (2 non-zeros each) with a boundary nonlinearity that maps the selected
  pair to `_trunc_div` / `_trunc_rem`. Weight budget goes 5 → 9 non-zero
  entries.
- `symbolic_programs_catalog.py` moves `native_divmod(2, 7)` and adds
  `native_remainder(2, 7)` into `collapsed` with an `is_rational` flag;
  `poly_expr` is rendered via the wrapper `__repr__`.
- Writeup updated (`dev/ff_symbolic_equivalence.md`) with the rational
  extension: types, matrices, weakened equivalence theorem, composition
  non-goal, corrected weight-budget arithmetic.

## Commits

1. `5809ea7` Extend Poly coefficients to Fraction
2. `b0ec4d9` Rational stack values for DIV_S / REM_S in symbolic executor
3. `382f965` Extend ff_symbolic with DIV_S / REM_S rational primitives
4. `1a962ab` Catalog + tests for rational (DIV_S / REM_S) rows
5. `e88381d` Rewrite dev/ff_symbolic_equivalence.md for the #75 extension
6. `fc7d2f5` Raise SymbolicOpNotSupported on arithmetic past rational entries
7. `e334473` Fix writeup typo: match SymbolicRemainder repr

## Test plan

- [x] `python3 test_symbolic_executor.py` — 19/19 passed
- [x] `python3 test_symbolic_programs_catalog.py` — 29/29 passed
- [x] `python3 test_ff_symbolic.py` — all checks passed, including:
  - `test_primitives_div_rem_s`
  - `test_primitives_rational_matrix_shapes`
  - `test_symbolic_rational_primitives`
  - `test_equivalence_rational`
  - `test_rational_catalog_rows_classify_as_collapsed`
  - `blocked[compose-past-DIV_S]`
- [x] Option (a) range-check semantics (non-negative inputs) verified
      against `NumPyExecutor`'s u32-masked top.

Closes #75.