### PR TITLE
M2: piecewise bilinear forms for comparisons (closes #76)

### DIFF
--- a/dev/ff_symbolic_equivalence.md
+++ b/dev/ff_symbolic_equivalence.md
@@ -1,6 +1,6 @@
 # FF symbolic equivalence — the weights ARE the polynomial
 
-_Issue #69 writeup. Follow-up to #65 (PR #66 symbolic executor, PR #67 catalog runner). Extended by #75 to cover DIV_S / REM_S via rational-pair algebra._
+_Issue #69 writeup. Follow-up to #65 (PR #66 symbolic executor, PR #67 catalog runner). Extended by #75 to cover DIV_S / REM_S via rational-pair algebra, and by #76 to cover comparisons (EQZ / EQ / NE / LT_S / GT_S / LE_S / GE_S) via gated bilinear forms with an `IndicatorPoly` sibling type._
 
 ## The claim, in one sentence
 
@@ -205,6 +205,189 @@ Two programs move from `blocked_opcode` to `collapsed`:
 because the single `eml(x, y) = exp(x) − ln(y)` operator has no
 division primitive.
 
+## Gated bilinear extension (issue #76)
+
+Comparisons (`EQZ`, `EQ`, `NE`, `LT_S`, `GT_S`, `LE_S`, `GE_S`) aren't
+polynomial operations over ℤ either — their outputs (0 or 1) depend on
+the **sign** of the input, not its algebraic structure. Issue #76
+carries the same idea that #75 used for rational ops into the
+comparison fragment:
+
+> Keep the polynomial fragment linear. Push the non-polynomial gate to
+> the boundary. Make the gate first-class rather than pretending it
+> isn't there.
+
+### The three moves
+
+1. **Symbolic executor: a new sibling type `IndicatorPoly`.**
+
+   ```python
+   @dataclass(frozen=True)
+   class IndicatorPoly:
+       poly: Poly        # the linear diff (pb − pa for binary cmps, pa for EQZ)
+       relation: str     # one of REL_EQ / REL_NE / REL_LT / REL_LE / REL_GT / REL_GE
+       def eval_at(self, bindings) -> int:
+           return int(_relation_holds(self.relation, self.poly.eval_at(bindings)))
+   ```
+
+   The polynomial stays pure (a linear diff). The gate lives in
+   `eval_at`. This is the **exact analogue of `RationalPoly`**: the
+   underlying `Poly` arithmetic is closed, the non-polynomial boundary
+   step (`_trunc_div` for rationals, `_relation_holds` for indicators)
+   fires only when a concrete integer is demanded.
+
+2. **`Guard` broadens from `eq_zero: bool` to `relation: str`.**
+
+   Pre-#76, a `Guard` meant "this polynomial equals zero" or "this
+   polynomial is nonzero" — the only relations JZ/JNZ branching
+   produced. Post-#76, a `Guard` carries any of the six relations.
+   `eq_zero` survives as a `@property` shim so existing code continues
+   to read the old semantics, but the canonical field is `relation`.
+
+   This lets JZ/JNZ consume an `IndicatorPoly` directly. Rather than
+   wrapping the indicator in an extra case-split, the executor **hoists**
+   the indicator's relation into the Guard pair:
+
+   ```python
+   # JZ on IndicatorPoly(poly=p, relation=LT) produces:
+   #   take_guard  (condition was 0 ⇒ ¬(p < 0))  : Guard(poly=p, relation=GE)
+   #   skip_guard  (condition was 1 ⇒ p < 0)     : Guard(poly=p, relation=LT)
+   ```
+
+   The `native_max` program — `GT_S; JZ skip; POP; HALT; skip: SWAP POP HALT` —
+   now collapses to a clean two-case `GuardedPoly`:
+
+   ```
+   Guarded[
+     {(x0 - x1 <= 0)} → x1,   # GT_S returned 0 ⇒ vb ≤ va ⇒ max is va = x1
+     {(x0 - x1 >  0)} → x0,   # GT_S returned 1 ⇒ vb > va ⇒ max is vb = x0
+   ]
+   ```
+
+   Note the guards carry `LE` / `GT` directly — not `EQ` / `NE` with
+   the indicator wrapped inside. The sign test the comparison opcode
+   implies is now the Guard's own relation.
+
+3. **`ff_symbolic`: two new linear matrices plus a relation gate.**
+
+   Comparisons decompose into **linear diff extraction** followed by a
+   **non-polynomial relation gate**:
+
+   | Op       | Weight tensor                                   | Shape        | Non-zero entries | Gate                  |
+   | -------- | ----------------------------------------------- | ------------ | ---------------: | --------------------- |
+   | Binary cmp | `M_CMP[0, DIM_VALUE] = -1`, `M_CMP[0, d+DIM_VALUE] = 1` | `(1, 2d)` | 2                | `1 if diff <rel> 0 else 0` |
+   | `EQZ`      | `M_EQZ[0, DIM_VALUE] = 1`                             | `(1, d)`   | 1                | `1 if va == 0 else 0` |
+
+   `forward_cmp(ea, eb, op)` computes `diff = M_CMP @ stack(ea, eb)`
+   (a scalar `vb − va`) then returns `E(_relation_holds(op_rel, diff))`.
+   `forward_eqz(ea)` is the `d`-wide variant for the unary case.
+
+   On the symbolic side, `symbolic_cmp(pa, pb, op)` returns
+   `IndicatorPoly(poly=pb - pa, relation=OP_RELATION[op])`; `symbolic_eqz(pa)`
+   returns `IndicatorPoly(poly=pa, relation=REL_EQ)`. The weight tensor's
+   polynomial interpretation is exactly this diff-extraction.
+
+   Total new non-zero weight budget: **3** (two for `M_CMP`, one for
+   `M_EQZ`). Running total after #69 + #75 + #76 is **12** non-zero
+   entries across seven matrices — the comparison fragment is cheaper
+   per-op than ADD/SUB because it only extracts a scalar, not a vector.
+
+### Equivalence theorem for the comparison fragment
+
+> For every comparison opcode `op ∈ {EQZ, EQ, NE, LT_S, GT_S, LE_S, GE_S}`
+> and every input embedding `ea, eb`:
+>
+> 1. **Structural.** `run_symbolic(P).top == forward_symbolic(P).top` on
+>    `IndicatorPoly` value-equality (same underlying `Poly`, same
+>    `relation` tag) for every program `P` ending on `op`.
+> 2. **Numeric (three-way).** `run_symbolic(P).top.eval_at(bindings) ==
+>    NumPyExecutor(P).top == TorchExecutor(P).top` for every `P` and
+>    every concrete bindings — the same agreement the `{ADD, SUB, MUL}`
+>    and `{DIV_S, REM_S}` fragments enjoy, now extended over the six
+>    signed comparison opcodes plus `EQZ`.
+> 3. **Dispatch.** If `op` is immediately consumed by `JZ` / `JNZ`, the
+>    resulting `GuardedPoly` has guards whose `relation` reflects the
+>    taken / skipped interpretation of the comparison, not a two-level
+>    `indicator == 0` / `indicator != 0` wrapping.
+
+Point (3) is the cosmetic-but-important payoff: the `GuardedPoly` for
+`native_max(a, b)` reads as *"if a ≤ b then b else a"* at the case-table
+level, without the reader having to unfold an intermediate indicator.
+
+### Catalog impact
+
+Two straight-line rows move from `blocked_opcode` to `collapsed`
+(`IndicatorPoly` tops):
+- `compare_lt_s(3, 5)` → `[x0 - x1 < 0]`, numeric = 1.
+- `compare_eqz(0)`    → `[x0 == 0]`, numeric = 1.
+
+One row moves from `blocked_opcode` to `collapsed_guarded`:
+- `native_max(3, 5)` → `Guarded[{x0 - x1 ≤ 0} → x1; {x0 - x1 > 0} → x0]`,
+  numeric = 5.
+
+eml-sr columns stay `–` for indicator rows — the single-operator family
+`eml(x, y) = exp(x) − ln(y)` has no sign primitive. The gate lives at
+the FF-dispatch boundary, not inside the polynomial the eml tree would
+compile. That's the same reason `is_rational` rows skip eml: the
+polynomial part of the tree is perfectly expressible, but the wrapping
+semantics aren't.
+
+### Composition non-goal
+
+Arithmetic composed on top of an `IndicatorPoly` (e.g. `LT_S` followed by
+`ADD`) raises `SymbolicOpNotSupported` / `BlockedOpcodeForSymbolic`,
+mirroring the rational-composition non-goal from #75. Supporting it
+would require either (a) promoting `IndicatorPoly` to a first-class
+piecewise polynomial algebra, or (b) materialising the 0/1 value
+eagerly — either of which defeats the "keep the polynomial fragment
+linear" principle. Out of scope for this issue.
+
+### Refactor plan: migrating S1 guards to sign indicators
+
+S1 (PR #71 / issue #70) introduced the forking executor with
+`Guard(poly, eq_zero=bool)`. Post-#76, `Guard.eq_zero` is a `@property`
+shim over the canonical `relation` field, but the *shape* of what
+guards can express is now strictly larger than it was in S1:
+
+- S1 guards only ever carried `REL_EQ` or `REL_NE` (the only relations
+  JZ/JNZ against a plain `Poly` could produce).
+- Post-#76 guards can carry any of six relations, because JZ/JNZ
+  consuming an `IndicatorPoly` *hoists* that indicator's relation
+  directly into the Guard.
+
+The S1 refactor to lean on sign indicators is already mostly done —
+this PR changed `Guard.relation` in place rather than keeping a parallel
+field. What still has pre-#76 phrasing and would be cosmetically nicer
+as signs:
+
+1. **`_as_concrete_int` collapses concrete `IndicatorPoly`** values to
+   0/1 at JZ/JNZ time. If a program happens to supply concrete pushes
+   all the way into a comparison, the stack entry is already a plain
+   `int` by the time `JZ` runs — the IndicatorPoly gets evaluated
+   eagerly. This keeps concrete-mode traces matching pre-#76 behavior.
+   No change needed; noted for readers.
+
+2. **S1 catalog rows (`select_by_sign`, `clamp_zero`, `either_or`)**
+   still render with `EQ/NE` guards in their `case_exprs`. That's
+   correct — these programs use plain JZ on a raw `Poly` (not an
+   `IndicatorPoly`), so the guard relations really *are* equality vs
+   inequality. The broader relation set only kicks in when a comparison
+   op feeds JZ/JNZ.
+
+3. **Follow-up opportunity.** The sign-indicator framework makes it
+   possible to *canonicalise* guards during `GuardedPoly` merges: two
+   cases whose guards are `{p < 0}` and `{p > 0}` could be proven
+   disjoint-but-not-covering (missing `p == 0`). Today the executor
+   doesn't do this reasoning. A future issue could add a guard
+   simplifier / coverage checker that uses the six-relation algebra
+   to detect redundant or missing cases. Not in this PR.
+
+The net effect: the S1 guard layer is now strictly richer, with no
+behavioral drift on pre-#76 rows (verified: `test_classify_guarded_on_symbolic_branch`
+and the `select_by_sign` / `clamp_zero` / `either_or` catalog pins
+still pass exactly, including the `{g.eq_zero for ...} == {True, False}`
+assertion that reads guards via the backward-compat property).
+
 ## Honest limits
 
 ### Range / i32-wrap
@@ -240,8 +423,12 @@ Listing these explicitly so the PR description stays honest:
   boundary trunc), but composition *past* a rational stack entry
   still raises. Full rational-function algebra (with GCD cancellation)
   is a follow-up.
-- **Comparisons** (EQ, LT_S, GT_S, …) — piecewise, need sign indicators
-  and/or Heaviside gating; out of scope.
+- **Comparisons** (EQ, LT_S, GT_S, …) — handled by issue #76 via
+  gated bilinear forms (linear diff extraction + relation gate at the
+  dispatch boundary). See the "Gated bilinear extension" section above.
+  Composition **past** a comparison (arithmetic on an `IndicatorPoly`)
+  is still out of scope; `IndicatorPoly` is a terminal wrapper like
+  `RationalPoly`.
 - **Bitwise** (AND, OR, XOR, shifts, rotates) — different algebra (mod-2
   bilinear forms over bit decompositions); out of scope.
 - **Unary ops** (CLZ, CTZ, POPCNT, ABS, NEG) — some are polynomial
@@ -299,9 +486,10 @@ Each of these is a separate issue:
   REM_S applied to an already-rational stack entry is the next bite.
   Needs GCD-based cancellation in the `Poly` ring (or a `RationalPoly`
   type with an explicit normal form).
-- **Piecewise bilinear forms** for comparisons. A sign-indicator
-  attention pattern gates into one of two output branches — the FF
-  counterpart of the symbolic executor's forking model (#70).
+- ~~**Piecewise bilinear forms** for comparisons.~~ **Done in #76.**
+  `IndicatorPoly` + gated bilinear forms (`M_CMP` / `M_EQZ` + relation
+  gate) realise the six signed comparisons + `EQZ`, and JZ/JNZ
+  consuming an indicator hoists its relation into the Guard pair.
 - **Mod-2 bilinear forms** for bitwise ops via bit decomposition. Same
   FF-layer machinery, different base ring.
 
@@ -310,7 +498,7 @@ visible.
 
 ## References
 
-- Parent issue: #65 · follow-ups: #69, #75
+- Parent issue: #65 · follow-ups: #69, #75, #76
 - Symbolic executor: PR #66
 - Catalog runner + eml bridge: PR #67
 - Forking / guarded execution: PR #71 (issue #70)
@@ -321,3 +509,10 @@ visible.
   `symbolic_div_s` / `symbolic_rem_s` to `ff_symbolic.py`, rational
   rows to `symbolic_programs_catalog.py`, and the rational section
   above to this writeup.
+- Comparison extension (gated bilinear forms): issue #76 — adds
+  `IndicatorPoly` sibling type and the six-relation `Guard` to
+  `symbolic_executor.py`, `M_CMP` / `M_EQZ` + `forward_cmp` /
+  `forward_eqz` + `symbolic_cmp` / `symbolic_eqz` to `ff_symbolic.py`,
+  indicator rows to `symbolic_programs_catalog.py`, and the "Gated
+  bilinear extension" + "Refactor plan" sections above to this
+  writeup.

--- a/executor.py
+++ b/executor.py
@@ -837,18 +837,31 @@ class CompiledModel(nn.Module):
             nonlinear[OPCODE_IDX[OP_REM_S]] = float(_trunc_rem(vb, va) & MASK32)
             nonlinear[OPCODE_IDX[OP_REM_U]] = float(_trunc_rem(vb, va) & MASK32)
 
-        # Comparison ops
-        nonlinear[OPCODE_IDX[OP_EQZ]]  = 1.0 if va == 0 else 0.0
-        nonlinear[OPCODE_IDX[OP_EQ]]   = 1.0 if va == vb else 0.0
-        nonlinear[OPCODE_IDX[OP_NE]]   = 1.0 if va != vb else 0.0
-        nonlinear[OPCODE_IDX[OP_LT_S]] = 1.0 if vb < va else 0.0
-        nonlinear[OPCODE_IDX[OP_LT_U]] = 1.0 if vb < va else 0.0
-        nonlinear[OPCODE_IDX[OP_GT_S]] = 1.0 if vb > va else 0.0
-        nonlinear[OPCODE_IDX[OP_GT_U]] = 1.0 if vb > va else 0.0
-        nonlinear[OPCODE_IDX[OP_LE_S]] = 1.0 if vb <= va else 0.0
-        nonlinear[OPCODE_IDX[OP_LE_U]] = 1.0 if vb <= va else 0.0
-        nonlinear[OPCODE_IDX[OP_GE_S]] = 1.0 if vb >= va else 0.0
-        nonlinear[OPCODE_IDX[OP_GE_U]] = 1.0 if vb >= va else 0.0
+        # Comparison ops — the six signed binary cmps and EQZ route
+        # through ff_symbolic's gated bilinear forms (M_CMP / M_EQZ,
+        # issue #76) so the numeric path matches the polynomial spec
+        # used by the symbolic executor. Unsigned variants share the
+        # signed result since operands are already i32 here (positive
+        # or two's-complement-extended identically for == / != and
+        # treat-as-signed via Python int for </>/<=/>=).
+        nonlinear[OPCODE_IDX[OP_EQZ]]  = float(ff_symbolic.E_inv(
+            ff_symbolic.forward_eqz(ea)))
+        nonlinear[OPCODE_IDX[OP_EQ]]   = float(ff_symbolic.E_inv(
+            ff_symbolic.forward_cmp(ea, eb, OP_EQ)))
+        nonlinear[OPCODE_IDX[OP_NE]]   = float(ff_symbolic.E_inv(
+            ff_symbolic.forward_cmp(ea, eb, OP_NE)))
+        nonlinear[OPCODE_IDX[OP_LT_S]] = float(ff_symbolic.E_inv(
+            ff_symbolic.forward_cmp(ea, eb, OP_LT_S)))
+        nonlinear[OPCODE_IDX[OP_LT_U]] = nonlinear[OPCODE_IDX[OP_LT_S]]
+        nonlinear[OPCODE_IDX[OP_GT_S]] = float(ff_symbolic.E_inv(
+            ff_symbolic.forward_cmp(ea, eb, OP_GT_S)))
+        nonlinear[OPCODE_IDX[OP_GT_U]] = nonlinear[OPCODE_IDX[OP_GT_S]]
+        nonlinear[OPCODE_IDX[OP_LE_S]] = float(ff_symbolic.E_inv(
+            ff_symbolic.forward_cmp(ea, eb, OP_LE_S)))
+        nonlinear[OPCODE_IDX[OP_LE_U]] = nonlinear[OPCODE_IDX[OP_LE_S]]
+        nonlinear[OPCODE_IDX[OP_GE_S]] = float(ff_symbolic.E_inv(
+            ff_symbolic.forward_cmp(ea, eb, OP_GE_S)))
+        nonlinear[OPCODE_IDX[OP_GE_U]] = nonlinear[OPCODE_IDX[OP_GE_S]]
 
         # Bitwise ops
         nonlinear[OPCODE_IDX[OP_AND]]   = float(_to_i32(va) & _to_i32(vb))

--- a/ff_symbolic.py
+++ b/ff_symbolic.py
@@ -1,4 +1,10 @@
-"""Bilinear FF dispatch for ADD/SUB/MUL (issue #69).
+"""Bilinear FF dispatch for ADD/SUB/MUL + DIV_S/REM_S + comparisons.
+
+Issue #69 introduced this module for the polynomial-closed core
+(ADD/SUB/MUL); issue #75 extended it to DIV_S / REM_S via a pair-
+selector matrix plus a boundary truncation; issue #76 extends it
+further to the comparison opcodes (EQ / NE / LT_S / GT_S / LE_S /
+GE_S / EQZ).
 
 Closes the gap between "the ISA semantics compose into a polynomial"
 (proven by :mod:`symbolic_executor`) and "the transformer weights
@@ -68,12 +74,51 @@ Composition past a single DIV_S / REM_S on the same stack slot is not
 supported in this issue — a subsequent arithmetic op on a rational
 stack entry raises ``SymbolicOpNotSupported``. That is a follow-up.
 
+Comparison extension (issue #76)
+--------------------------------
+WASM ``i32.eq`` / ``i32.lt_s`` / ... return ``1 if (vb REL va) else 0``,
+a piecewise function: not polynomial. We model them as **gated bilinear
+forms**: a *linear* matrix ``M_CMP`` extracts the single scalar
+``vb − va`` from the stacked input, and the relation gate
+``1 if (diff REL 0) else 0`` is applied at the boundary — the same
+"polynomial inside, non-polynomial step at the edge" pattern DIV_S /
+REM_S already use. EQZ is the unary case: ``M_EQZ`` extracts ``va``
+and the gate fires on ``va == 0``.
+
+This is "gated" rather than truly bilinear because the gate fires
+*after* the linear extraction — ``B = e_DIM_VALUE ⊗ e_DIM_VALUE``
+would be the bilinear product (used by MUL); for comparisons the
+output is a Boolean indicator on the difference, not the product.
+Symbolically this becomes :class:`symbolic_executor.IndicatorPoly` —
+a (poly, relation) pair whose ``eval_at`` applies the gate.
+
+The cost is the same as DIV_S: comparisons leave the polynomial ring,
+so composition past one comparison (e.g. ``LT_S; ADD``) raises
+:class:`BlockedOpcodeForSymbolic`. The catalog rows this unblocks
+(``compare_lt_s``, ``compare_eqz``, ``native_max``) all either halt
+on the indicator directly or feed it to JZ/JNZ, where the forking
+executor hoists the relation into a :class:`Guard` rather than
+composing it.
+
+Refactoring guards as sign indicators (S1 follow-up)
+----------------------------------------------------
+Pre-#76 :class:`Guard` only carried an ``eq_zero: bool``. M2 broadens
+it to a six-relation enum so the same data shape that backs
+``IndicatorPoly`` also backs guards — i.e. a guard *is* a sign
+indicator we've asserted to hold along a path. PR #71's S1 worked
+hard to express LT_S/GE_S/etc. via "synthetic ``cond − threshold``"
+guards on the EQ/NE-only Guard; once everything goes through the
+relation field, that synthesis collapses to a straight pass-through.
+The catalog renderer (``symbolic_programs_catalog._guard_to_expr``)
+is the natural follow-up site to migrate.
+
 Scope
 -----
 ADD/SUB/MUL via true (bi)linear forms; DIV_S/REM_S via pair-selector
-+ boundary trunc (issue #75). Comparisons, bitwise, unary numeric
-ops, control flow — all unchanged, and all explicit follow-ups per
-the issue's "Non-goals" section.
++ boundary trunc (issue #75); comparisons via diff-extractor +
+relation gate (issue #76). Bitwise, unary numeric ops, control
+flow — all unchanged, and all explicit follow-ups per the issue's
+"Non-goals" section.
 """
 
 from __future__ import annotations
@@ -88,10 +133,13 @@ from isa import DIM_VALUE, D_MODEL, DTYPE, _trunc_div, _trunc_rem
 from symbolic_executor import (
     ArithmeticOps,
     ForkingResult,
+    IndicatorPoly,
     Poly,
     RationalPoly,
     RationalStackValue,
+    REL_EQ, REL_NE, REL_LT, REL_LE, REL_GT, REL_GE,
     SymbolicRemainder,
+    _relation_holds,
     run_forking,
 )
 
@@ -229,24 +277,68 @@ def _M_REM_S_matrix(d_model: int = D_MODEL) -> torch.Tensor:
     return W
 
 
+def _M_CMP_matrix(d_model: int = D_MODEL) -> torch.Tensor:
+    """Diff-extractor for binary comparisons (issue #76).
+
+    Shape: ``(1, 2*d_model)``. Computes the single scalar
+    ``diff = vb - va`` from the stacked input ``[E(a); E(b)]``. The
+    relation gate (``1 if diff REL 0 else 0``) is applied at the
+    boundary by :func:`forward_cmp`, mirroring the DIV_S boundary-trunc
+    pattern.
+
+    All six binary comparisons share this matrix — only the gate
+    differs. Two non-zero entries: ``-1`` at ``DIM_VALUE`` (coefficient
+    of ``va``, the top), ``+1`` at ``d_model + DIM_VALUE`` (coefficient
+    of ``vb``, stack[SP-1]).
+    """
+    W = torch.zeros(1, 2 * d_model, dtype=DTYPE)
+    W[0, DIM_VALUE] = -1.0                          # coefficient of a (top)
+    W[0, d_model + DIM_VALUE] = 1.0                 # coefficient of b (SP-1)
+    return W
+
+
+def _M_EQZ_matrix(d_model: int = D_MODEL) -> torch.Tensor:
+    """Single-value extractor for EQZ (issue #76).
+
+    Shape: ``(1, d_model)``. Plucks ``va`` from ``E(a)`` so the gate
+    can fire on ``va == 0`` at the boundary. EQZ is the unary
+    degenerate case of the comparison family — the difference
+    extraction collapses to "just read the value".
+    """
+    W = torch.zeros(1, d_model, dtype=DTYPE)
+    W[0, DIM_VALUE] = 1.0
+    return W
+
+
 # Module-scope cached tensors — read-only; wrapped on access.
 M_ADD: torch.Tensor = _M_ADD_matrix()
 M_SUB: torch.Tensor = _M_SUB_matrix()
 B_MUL: torch.Tensor = _B_MUL_matrix()
 M_DIV_S: torch.Tensor = _M_DIV_S_matrix()
 M_REM_S: torch.Tensor = _M_REM_S_matrix()
+M_CMP: torch.Tensor = _M_CMP_matrix()
+M_EQZ: torch.Tensor = _M_EQZ_matrix()
 
 
 def n_parameters(d_model: int = D_MODEL) -> int:
     """Parameter count contributed by the analytically-set FF weights.
 
-    Counts non-zero entries across all five matrices:
-    2 (M_ADD) + 2 (M_SUB) + 1 (B_MUL) + 2 (M_DIV_S) + 2 (M_REM_S) = 9.
-    The stored tensors are larger but the analytically-set content is nine
-    bits. Issue #69 shipped with the first three (for 5 non-zeros); issue
-    #75 added M_DIV_S / M_REM_S.
+    Counts non-zero entries across all matrices:
+
+    * ``M_ADD``     2 (two ``+1`` coefficients)
+    * ``M_SUB``     2 (one ``+1``, one ``-1``)
+    * ``B_MUL``     1 (single rank-1 outer product)
+    * ``M_DIV_S``   2 (pair-selector for ``(va, vb)``)
+    * ``M_REM_S``   2 (pair-selector for ``(va, vb)``)
+    * ``M_CMP``     2 (diff-extractor; shared by all six binary comparisons)
+    * ``M_EQZ``     1 (single-value extractor)
+
+    Total: 12. The stored tensors are larger but the analytically-set
+    content is twelve bits. The six binary comparisons share ``M_CMP``
+    so their cost is the matrix entries plus six relation gates (the
+    gates are control-flow, not parameters).
     """
-    return 9
+    return 12
 
 
 # ─── Numeric primitives (float tensors) ───────────────────────────
@@ -316,6 +408,62 @@ def forward_rem_s(ea: torch.Tensor, eb: torch.Tensor) -> torch.Tensor:
     return out
 
 
+# Map from comparison opcode (binary) to the relation code applied to
+# ``vb − va``. Single source of truth shared by the symbolic and
+# numeric forward paths so they cannot drift.
+_OP_RELATION = {
+    isa.OP_EQ: REL_EQ,
+    isa.OP_NE: REL_NE,
+    isa.OP_LT_S: REL_LT,
+    isa.OP_GT_S: REL_GT,
+    isa.OP_LE_S: REL_LE,
+    isa.OP_GE_S: REL_GE,
+}
+
+
+def forward_cmp(ea: torch.Tensor, eb: torch.Tensor, op: int) -> torch.Tensor:
+    """Compute ``E(1 if (vb REL va) else 0)`` for one of the six binary cmps.
+
+    ``op`` is one of ``isa.OP_EQ / OP_NE / OP_LT_S / OP_GT_S / OP_LE_S
+    / OP_GE_S``. Applies ``M_CMP`` as a diff-extractor (``diff = vb - va``
+    via the ``(1, 2*d_model)`` linear form), then the relation gate at
+    the boundary. The output is re-embedded via ``E`` so the result
+    shares the same scalar-at-``DIM_VALUE`` layout as every other value
+    in the model — a downstream FF can read it back without any
+    re-projection.
+
+    The gate is an ``int(_relation_holds(...))`` call: not a matmul.
+    That's the honest cost of integer-valued comparisons in a polynomial
+    framework — same shape as DIV_S's ``_trunc_div`` boundary step.
+    """
+    relation = _OP_RELATION.get(op)
+    if relation is None:
+        raise ValueError(
+            f"forward_cmp: op {isa.OP_NAMES.get(op, op)!r} is not a "
+            f"binary comparison opcode (expected one of {sorted(_OP_RELATION)})"
+        )
+    stacked = torch.cat([ea, eb])                    # shape (2*d_model,)
+    diff = float((M_CMP @ stacked).item())           # shape (), then scalar
+    bit = 1 if _relation_holds(relation, diff) else 0
+    out = torch.zeros(ea.shape[0], dtype=DTYPE)
+    out[DIM_VALUE] = float(bit)
+    return out
+
+
+def forward_eqz(ea: torch.Tensor) -> torch.Tensor:
+    """Compute ``E(1 if va == 0 else 0)`` from ``E(a)``.
+
+    Applies ``M_EQZ`` as a single-value extractor (``va = ea[DIM_VALUE]``
+    via the ``(1, d_model)`` linear form), then the equality gate at
+    the boundary. Unary degenerate case of :func:`forward_cmp`.
+    """
+    va = float((M_EQZ @ ea).item())
+    bit = 1 if _relation_holds(REL_EQ, va) else 0
+    out = torch.zeros(ea.shape[0], dtype=DTYPE)
+    out[DIM_VALUE] = float(bit)
+    return out
+
+
 # ─── Symbolic primitives (Poly values) ────────────────────────────
 #
 # These ARE polynomial algebra — ``Poly`` overloads ``+ - *`` — but they
@@ -361,11 +509,43 @@ def symbolic_rem_s(pa: Poly, pb: Poly) -> SymbolicRemainder:
     return SymbolicRemainder(num=pb, denom=pa)
 
 
+def symbolic_cmp(pa: Poly, pb: Poly, op: int) -> IndicatorPoly:
+    """Symbolic comparison; corresponds to ``forward_cmp`` over :class:`Poly`.
+
+    Order matches ``forward_cmp`` (``pa`` is top, ``pb`` is stack[SP-1]):
+    returns ``IndicatorPoly(poly=pb - pa, relation=_OP_RELATION[op])`` so
+    that ``vb REL va`` becomes ``(pb - pa) REL 0`` — the same identity
+    ``M_CMP``'s linear extraction realises numerically.
+
+    The gate fires only at :meth:`IndicatorPoly.eval_at`, mirroring
+    :class:`RationalPoly`'s boundary truncation. Composition past this
+    point (e.g. ``LT_S; ADD``) raises
+    :class:`symbolic_executor.SymbolicOpNotSupported` upstream.
+    """
+    relation = _OP_RELATION.get(op)
+    if relation is None:
+        raise ValueError(
+            f"symbolic_cmp: op {isa.OP_NAMES.get(op, op)!r} is not a "
+            f"binary comparison opcode (expected one of {sorted(_OP_RELATION)})"
+        )
+    return IndicatorPoly(poly=pb - pa, relation=relation)
+
+
+def symbolic_eqz(pa: Poly) -> IndicatorPoly:
+    """Symbolic EQZ; corresponds to ``forward_eqz`` over :class:`Poly`.
+
+    Returns ``IndicatorPoly(poly=pa, relation=REL_EQ)``; the gate
+    ``pa == 0`` fires at :meth:`IndicatorPoly.eval_at`.
+    """
+    return IndicatorPoly(poly=pa, relation=REL_EQ)
+
+
 # Arithmetic primitives packaged for :func:`symbolic_executor.run_forking`'s
-# ``arithmetic_ops`` hook (issue #68 S3; extended for DIV_S/REM_S in #75).
-# The wrappers flip arg order where needed: the forking executor's convention
-# is ``op(a, b)`` with ``a`` = stack[SP-1] and ``b`` = top. ``symbolic_sub`` /
-# ``symbolic_div_s`` / ``symbolic_rem_s`` are written in the FF ``(pa, pb)``
+# ``arithmetic_ops`` hook (issue #68 S3; extended for DIV_S/REM_S in #75;
+# extended for the comparison family in #76). The wrappers flip arg order
+# where needed: the forking executor's convention is ``op(a, b)`` with
+# ``a`` = stack[SP-1] and ``b`` = top. ``symbolic_sub`` / ``symbolic_div_s``
+# / ``symbolic_rem_s`` / ``symbolic_cmp`` are written in the FF ``(pa, pb)``
 # order where ``pa`` = top, ``pb`` = SP-1, so we call them with ``(b, a)``.
 FF_ARITHMETIC_OPS = ArithmeticOps(
     add=lambda a, b: symbolic_add(a, b),
@@ -373,6 +553,13 @@ FF_ARITHMETIC_OPS = ArithmeticOps(
     mul=lambda a, b: symbolic_mul(a, b),
     div_s=lambda a, b: symbolic_div_s(b, a),
     rem_s=lambda a, b: symbolic_rem_s(b, a),
+    cmp_eq=lambda a, b: symbolic_cmp(b, a, isa.OP_EQ),
+    cmp_ne=lambda a, b: symbolic_cmp(b, a, isa.OP_NE),
+    cmp_lt_s=lambda a, b: symbolic_cmp(b, a, isa.OP_LT_S),
+    cmp_gt_s=lambda a, b: symbolic_cmp(b, a, isa.OP_GT_S),
+    cmp_le_s=lambda a, b: symbolic_cmp(b, a, isa.OP_LE_S),
+    cmp_ge_s=lambda a, b: symbolic_cmp(b, a, isa.OP_GE_S),
+    eqz=lambda a: symbolic_eqz(a),
 )
 
 
@@ -387,6 +574,9 @@ _SCOPE_OPS = {
     isa.OP_PUSH, isa.OP_POP, isa.OP_DUP, isa.OP_HALT, isa.OP_NOP,
     isa.OP_ADD, isa.OP_SUB, isa.OP_MUL,
     isa.OP_DIV_S, isa.OP_REM_S,
+    isa.OP_EQ, isa.OP_NE,
+    isa.OP_LT_S, isa.OP_GT_S, isa.OP_LE_S, isa.OP_GE_S,
+    isa.OP_EQZ,
     isa.OP_SWAP, isa.OP_OVER, isa.OP_ROT,
 }
 
@@ -444,7 +634,8 @@ def evaluate_program(prog) -> SymbolicForwardResult:
         if op not in _SCOPE_OPS:
             raise BlockedOpcodeForSymbolic(
                 f"op {isa.OP_NAMES.get(op, f'?{op}')!r} is out of scope for the "
-                f"bilinear FF dispatch (ADD/SUB/MUL/DIV_S/REM_S + stack manip only)"
+                f"bilinear FF dispatch (ADD/SUB/MUL/DIV_S/REM_S + comparisons "
+                f"+ stack manip only)"
             )
         if op == isa.OP_HALT:
             break
@@ -479,6 +670,17 @@ def evaluate_program(prog) -> SymbolicForwardResult:
         elif op == isa.OP_REM_S:
             b = _require_poly(_pop(), "REM_S"); a = _require_poly(_pop(), "REM_S")
             stack.append(symbolic_rem_s(b, a))
+        elif op in _OP_RELATION:
+            # Binary comparison (issue #76). Pop order / arg convention
+            # matches the arithmetic ops above: b = top, a = SP-1. The
+            # symbolic primitive takes (pa, pb) in FF order (pa=top,
+            # pb=SP-1), so we call symbolic_cmp(b, a, op).
+            name = isa.OP_NAMES.get(op, f"?{op}")
+            b = _require_poly(_pop(), name); a = _require_poly(_pop(), name)
+            stack.append(symbolic_cmp(b, a, op))
+        elif op == isa.OP_EQZ:
+            a = _require_poly(_pop(), "EQZ")
+            stack.append(symbolic_eqz(a))
         elif op == isa.OP_SWAP:
             if len(stack) < 2:
                 raise IndexError("swap needs 2 entries")
@@ -529,12 +731,14 @@ __all__ = [
     "RangeCheckFailure",
     "I32_MIN", "I32_MAX",
     "E", "E_inv",
-    "M_ADD", "M_SUB", "B_MUL", "M_DIV_S", "M_REM_S",
+    "M_ADD", "M_SUB", "B_MUL", "M_DIV_S", "M_REM_S", "M_CMP", "M_EQZ",
     "n_parameters",
     "forward_add", "forward_sub", "forward_mul",
     "forward_div_s", "forward_rem_s",
+    "forward_cmp", "forward_eqz",
     "symbolic_add", "symbolic_sub", "symbolic_mul",
     "symbolic_div_s", "symbolic_rem_s",
+    "symbolic_cmp", "symbolic_eqz",
     "FF_ARITHMETIC_OPS",
     "SymbolicForwardResult",
     "evaluate_program",

--- a/symbolic_executor.py
+++ b/symbolic_executor.py
@@ -235,6 +235,103 @@ class Poly:
         return out
 
 
+# ─── Sign-indicator form (issue #76) ──────────────────────────────
+#
+# Comparisons (EQ, NE, LT_S, GT_S, LE_S, GE_S, EQZ) are not polynomial
+# operations on integer values: they're piecewise — 1 when a relation
+# holds, 0 otherwise. Symbolically we carry the comparison forward as a
+# (poly, relation) pair via :class:`IndicatorPoly`. Truncation to {0, 1}
+# happens only at :meth:`IndicatorPoly.eval_at`, the boundary step —
+# matching the same "polynomial-ring inside, non-poly step at the edge"
+# pattern :class:`RationalPoly` and :class:`SymbolicRemainder` already use
+# for DIV_S / REM_S.
+#
+# Composition past one comparison (e.g. ADD on top of an IndicatorPoly)
+# is out of scope — the consuming opcode raises
+# :class:`SymbolicOpNotSupported`. The catalog rows this unblocks
+# (``compare_lt_s``, ``compare_eqz``, ``native_max``, ...) all either
+# halt on the indicator directly (collapse to a non-Poly top) or pass it
+# straight to a JZ/JNZ that the forking executor turns into a guarded
+# split. Either way, the indicator never has to compose with another
+# arithmetic op.
+
+# Relation codes — comparisons are uniformly ``poly REL 0``, where REL
+# is one of these six. EQZ folds into ``IndicatorPoly(va, REL_EQ)`` (the
+# unary case is a degenerate binary one). Binary comparisons reduce to
+# the relation on the difference ``vb - va`` so a single shared diff
+# matrix suffices on the FF side (see ``ff_symbolic.M_CMP``).
+REL_EQ = "EQ"
+REL_NE = "NE"
+REL_LT = "LT"
+REL_LE = "LE"
+REL_GT = "GT"
+REL_GE = "GE"
+_RELATIONS = (REL_EQ, REL_NE, REL_LT, REL_LE, REL_GT, REL_GE)
+
+# Pretty-print symbols for guard / indicator repr.
+_REL_SYMBOL = {
+    REL_EQ: "==", REL_NE: "!=",
+    REL_LT: "<",  REL_LE: "<=",
+    REL_GT: ">",  REL_GE: ">=",
+}
+
+# Negation table — used when JZ/JNZ pops an IndicatorPoly: the "not
+# taken" branch carries the negated relation as its guard.
+_NEGATE_REL = {
+    REL_EQ: REL_NE, REL_NE: REL_EQ,
+    REL_LT: REL_GE, REL_GE: REL_LT,
+    REL_LE: REL_GT, REL_GT: REL_LE,
+}
+
+
+def _relation_holds(rel: str, value: Union[int, Fraction]) -> bool:
+    """Evaluate ``value REL 0`` for the given relation code."""
+    if rel == REL_EQ: return value == 0
+    if rel == REL_NE: return value != 0
+    if rel == REL_LT: return value <  0
+    if rel == REL_LE: return value <= 0
+    if rel == REL_GT: return value >  0
+    if rel == REL_GE: return value >= 0
+    raise ValueError(f"unknown relation {rel!r}")
+
+
+@dataclass(frozen=True)
+class IndicatorPoly:
+    """Sign indicator on a polynomial: ``1 if poly REL 0 else 0``.
+
+    Carries a comparison's symbolic result through the stack without
+    leaving the polynomial ring at the *expression* level — the gate
+    fires only at :meth:`eval_at`, mirroring the boundary-truncation
+    pattern :class:`RationalPoly` uses for DIV_S. The wrapped ``poly``
+    is the (vb − va) difference for binary comparisons or the unary
+    operand directly for EQZ; ``relation`` is one of
+    ``REL_EQ, REL_NE, REL_LT, REL_LE, REL_GT, REL_GE``.
+
+    Composition past an :class:`IndicatorPoly` (e.g. another ADD) is
+    out of scope for issue #76 — the consuming op raises
+    :class:`SymbolicOpNotSupported`, matching the rational story.
+    """
+    poly: Poly
+    relation: str
+
+    def __post_init__(self):
+        if self.relation not in _RELATIONS:
+            raise ValueError(
+                f"IndicatorPoly.relation must be one of {_RELATIONS}, "
+                f"got {self.relation!r}"
+            )
+
+    def variables(self) -> List[int]:
+        return self.poly.variables()
+
+    def eval_at(self, bindings: Mapping[int, int]) -> int:
+        v = self.poly.eval_at(bindings)
+        return 1 if _relation_holds(self.relation, v) else 0
+
+    def __repr__(self) -> str:
+        return f"[{self.poly} {_REL_SYMBOL[self.relation]} 0]"
+
+
 # ─── Rational + remainder forms (issue #75) ───────────────────────
 #
 # DIV_S / REM_S break out of the polynomial ring: integer division is
@@ -333,41 +430,83 @@ RationalStackValue = Union[Poly, RationalPoly, SymbolicRemainder]
 
 # ─── Guard + GuardedPoly ──────────────────────────────────────────
 #
-# A guard is a polynomial we assert is either "== 0" or "!= 0". A
-# conjunction is a tuple of guards that must all hold simultaneously.
-# GuardedPoly is a case table — one (conjunction, value_poly) entry per
-# partition of the input domain.
+# A guard is a polynomial we assert satisfies one of six relations vs
+# zero (``== / != / < / <= / > / >=``). A conjunction is a tuple of
+# guards that must all hold simultaneously. GuardedPoly is a case
+# table — one (conjunction, value_poly) entry per partition of the
+# input domain.
 #
-# Guards are value-compared on (poly, eq_zero), so two paths that derive
-# the same guard chain in different orders merge cleanly after sorting.
+# Guards are value-compared on (poly, relation), so two paths that
+# derive the same guard chain in different orders merge cleanly after
+# sorting. Issue #76 broadened the relation field from a binary
+# ``eq_zero`` flag to the full six-relation set so that JZ/JNZ on an
+# :class:`IndicatorPoly` cond produces guards that carry the comparison's
+# semantics — not just an "== 0 / != 0" approximation. The
+# :attr:`Guard.eq_zero` property survives as backwards-compat shorthand.
 
 
 @dataclass(frozen=True)
 class Guard:
-    """Assertion that ``poly == 0`` (eq_zero=True) or ``poly != 0``."""
+    """Assertion ``poly REL 0`` for one of the six standard relations.
+
+    ``relation`` is one of ``REL_EQ, REL_NE, REL_LT, REL_LE, REL_GT,
+    REL_GE``. Pre-issue-#76 code only spoke of ``eq_zero=True/False``;
+    that's preserved as a derived property for the dedup-by-(poly,
+    eq_zero) call sites that have not been migrated. New code should
+    construct guards via the relation directly.
+    """
     poly: Poly
-    eq_zero: bool
+    relation: str
+
+    def __post_init__(self):
+        if self.relation not in _RELATIONS:
+            raise ValueError(
+                f"Guard.relation must be one of {_RELATIONS}, "
+                f"got {self.relation!r}"
+            )
+
+    @property
+    def eq_zero(self) -> bool:
+        """Backwards-compat shim — True iff this guard asserts ``poly == 0``.
+
+        Pre-#76 ``Guard`` only had ``eq_zero`` (True/False). The
+        property keeps that read-side API working for the
+        equality/inequality-only callers that haven't migrated to the
+        full relation enum. Comparison-derived guards (``LT/LE/GT/GE``)
+        return ``False`` here, since they don't assert equality with
+        zero — callers that need to distinguish them should switch to
+        ``g.relation``.
+        """
+        return self.relation == REL_EQ
+
+    def holds_at(self, bindings: Mapping[int, int]) -> bool:
+        """True iff ``poly REL 0`` holds at the given bindings."""
+        return _relation_holds(self.relation, self.poly.eval_at(bindings))
 
     def __repr__(self) -> str:
-        op = "==" if self.eq_zero else "!="
-        return f"({self.poly} {op} 0)"
+        return f"({self.poly} {_REL_SYMBOL[self.relation]} 0)"
 
 
 def _canonical_guards(guards: Tuple[Guard, ...]) -> Tuple[Guard, ...]:
     """Deduplicate + sort a guard conjunction for value-based equality."""
     # Use hash-based dedupe; Guard is frozen so hashable.
-    return tuple(sorted(set(guards), key=lambda g: (repr(g.poly), g.eq_zero)))
+    return tuple(sorted(set(guards), key=lambda g: (repr(g.poly), g.relation)))
 
 
 def _guards_complementary(a: Tuple[Guard, ...], b: Tuple[Guard, ...]) -> bool:
-    """True iff a and b differ on exactly one guard by `eq_zero` flip."""
+    """True iff a and b differ on exactly one guard by relation negation.
+
+    Two relations are complementary if one is the other's :data:`_NEGATE_REL`
+    image — i.e. ``EQ↔NE``, ``LT↔GE``, ``LE↔GT``. Used by callers that
+    want to detect "these two cases together cover the full domain" merges.
+    """
     if len(a) != len(b):
         return False
     diff = 0
     for ga, gb in zip(a, b):
         if ga == gb:
             continue
-        if ga.poly == gb.poly and ga.eq_zero != gb.eq_zero:
+        if ga.poly == gb.poly and _NEGATE_REL[ga.relation] == gb.relation:
             diff += 1
         else:
             return False

--- a/symbolic_executor.py
+++ b/symbolic_executor.py
@@ -28,8 +28,20 @@ Issue #70 extends the executor past straight-line code:
     path halts with ``loop_symbolic`` — we don't attempt invariant
     inference.
 
+Issue #75 lifts DIV_S / REM_S out of scope: they emit
+:class:`RationalPoly` / :class:`SymbolicRemainder` boundary types so the
+ring stays closed inside the executor and truncation lives at
+``eval_at``. Issue #76 does the same for the comparison opcodes (EQ,
+NE, LT_S, GT_S, LE_S, GE_S, EQZ): the result is an
+:class:`IndicatorPoly` carrying ``poly`` + ``relation``, evaluated to
+{0, 1} only at the boundary. JZ/JNZ on an :class:`IndicatorPoly` cond
+hoists the relation directly into the resulting :class:`Guard` so a
+``LT_S; JZ ...`` pair produces a ``GuardedPoly`` whose cases carry
+``<`` / ``>=`` semantics — not just ``== 0`` / ``!= 0``.
+
 Out of scope (file as follow-ups):
-  - Non-polynomial opcodes (DIV_S, REM_S, comparisons, bitwise).
+  - Bitwise opcodes (AND/OR/XOR/SHL/SHR_S/SHR_U/ROTL/ROTR).
+  - Composition past one DIV_S/REM_S/comparison (e.g. ``LT_S; ADD``).
   - Loop-invariant inference for truly symbolic loops.
   - Locals, heap, memory — no symbolic address model yet.
   - Emitting W_Q/W_K/W_V themselves as expression trees (the issue's
@@ -424,8 +436,10 @@ class SymbolicRemainder:
 
 
 # Union covering every "top of symbolic stack" type run_symbolic /
-# run_forking might emit for a branchless polynomial-plus-rational program.
-RationalStackValue = Union[Poly, RationalPoly, SymbolicRemainder]
+# run_forking might emit for a branchless polynomial-plus-rational-plus-
+# indicator program. Issue #76 added :class:`IndicatorPoly` to carry
+# comparison results (EQ/NE/LT_S/GT_S/LE_S/GE_S/EQZ) through the stack.
+RationalStackValue = Union[Poly, RationalPoly, SymbolicRemainder, IndicatorPoly]
 
 
 # ─── Guard + GuardedPoly ──────────────────────────────────────────
@@ -555,10 +569,7 @@ class GuardedPoly:
                 except KeyError:
                     ok = False
                     break
-                if g.eq_zero and val != 0:
-                    ok = False
-                    break
-                if not g.eq_zero and val == 0:
+                if not _relation_holds(g.relation, val):
                     ok = False
                     break
             if ok:
@@ -586,12 +597,35 @@ class GuardedPoly:
 # (outputs are :class:`RationalPoly` / :class:`SymbolicRemainder`) but
 # the executor still accepts them as long as nothing downstream tries to
 # compose a Poly op against a rational stack entry.
+# Issue #76 adds the comparisons (EQ / NE / LT_S / GT_S / LE_S / GE_S /
+# EQZ): they break the ring too, producing :class:`IndicatorPoly` tops.
+# Same composition rule applies — the consuming op must be HALT or
+# JZ/JNZ.
+_CMP_BIN_OPS = {
+    isa.OP_EQ, isa.OP_NE,
+    isa.OP_LT_S, isa.OP_GT_S, isa.OP_LE_S, isa.OP_GE_S,
+}
+_CMP_UNARY_OPS = {isa.OP_EQZ}
+_CMP_OPS = _CMP_BIN_OPS | _CMP_UNARY_OPS
+
+# Per-op (binary) relation when wrapping ``IndicatorPoly(a - b, REL)``,
+# where ``a = stack[SP-1]`` (the WASM ``vb``) and ``b = top`` (``va``).
+# This matches :file:`executor.py:230-245` ("``1 if vb < va else 0``" etc.).
+_BIN_OP_RELATION = {
+    isa.OP_EQ: REL_EQ,
+    isa.OP_NE: REL_NE,
+    isa.OP_LT_S: REL_LT,
+    isa.OP_GT_S: REL_GT,
+    isa.OP_LE_S: REL_LE,
+    isa.OP_GE_S: REL_GE,
+}
+
 _POLY_OPS = {
     isa.OP_PUSH, isa.OP_POP, isa.OP_DUP, isa.OP_HALT,
     isa.OP_ADD, isa.OP_SUB, isa.OP_MUL,
     isa.OP_DIV_S, isa.OP_REM_S,
     isa.OP_SWAP, isa.OP_OVER, isa.OP_ROT, isa.OP_NOP,
-}
+} | _CMP_OPS
 # Branch ops the forking executor additionally handles.
 _BRANCH_OPS = {isa.OP_JZ, isa.OP_JNZ}
 # Union: what run_forking accepts.
@@ -666,12 +700,12 @@ def run_symbolic(prog: List[isa.Instruction]) -> SymbolicResult:
     issue-#65 "branchless only" contract. Use :func:`run_forking` for
     programs with JZ/JNZ.
     """
-    stack: List[Poly] = []
+    stack: List[RationalStackValue] = []
     bindings: Dict[int, int] = {}
     next_var = 0
     n_heads = 0
 
-    def _pop() -> Poly:
+    def _pop() -> RationalStackValue:
         if not stack:
             raise SymbolicStackUnderflow("pop from empty stack")
         return stack.pop()
@@ -744,6 +778,25 @@ def run_symbolic(prog: List[isa.Instruction]) -> SymbolicResult:
                     "(composition past one DIV_S/REM_S is a follow-up)"
                 )
             stack.append(SymbolicRemainder(num=a, denom=b))
+        elif op in _CMP_BIN_OPS:
+            b = _pop(); a = _pop()
+            if not isinstance(a, Poly) or not isinstance(b, Poly):
+                raise SymbolicOpNotSupported(
+                    f"{isa.OP_NAMES[op]} on non-Poly stack entries is out "
+                    "of scope (composition past one DIV_S/REM_S/comparison "
+                    "is a follow-up)"
+                )
+            # WASM convention: ``a = stack[SP-1]`` (vb), ``b = top`` (va).
+            # The relation table maps each op to ``vb REL va`` ⇔ ``a - b REL 0``.
+            stack.append(IndicatorPoly(poly=a - b, relation=_BIN_OP_RELATION[op]))
+        elif op == isa.OP_EQZ:
+            a = _pop()
+            if not isinstance(a, Poly):
+                raise SymbolicOpNotSupported(
+                    "EQZ on non-Poly stack entries is out of scope "
+                    "(composition past one DIV_S/REM_S/comparison is a follow-up)"
+                )
+            stack.append(IndicatorPoly(poly=a, relation=REL_EQ))
         elif op == isa.OP_SWAP:
             if len(stack) < 2:
                 raise SymbolicStackUnderflow("swap needs 2 entries")
@@ -784,6 +837,8 @@ def run_symbolic(prog: List[isa.Instruction]) -> SymbolicResult:
 ArithFn = Callable[["Poly", "Poly"], "Poly"]
 DivFn = Callable[["Poly", "Poly"], "RationalPoly"]
 RemFn = Callable[["Poly", "Poly"], "SymbolicRemainder"]
+CmpBinFn = Callable[["Poly", "Poly"], "IndicatorPoly"]
+CmpUnaryFn = Callable[["Poly"], "IndicatorPoly"]
 
 
 @dataclass(frozen=True)
@@ -800,12 +855,41 @@ class ArithmeticOps:
     ``i32.div_s`` / ``i32.rem_s`` semantics — ``a`` is stack[SP-1] (the
     dividend) and ``b`` is top (the divisor), matching the numeric
     path's ``_trunc_div(vb, va)`` convention (``executor.py:835-838``).
+
+    ``cmp_eq / cmp_ne / cmp_lt_s / cmp_gt_s / cmp_le_s / cmp_ge_s``
+    (issue #76) must return an :class:`IndicatorPoly` capturing
+    "``vb REL va`` ⇔ ``a - b REL 0``" under the same ``a = SP-1, b =
+    top`` convention. ``eqz(a)`` returns the unary "``a == 0``"
+    indicator. The ``cmp(op)`` helper resolves an opcode to the right
+    primitive — used by :func:`_apply_poly_op`.
     """
     add: ArithFn
     sub: ArithFn
     mul: ArithFn
     div_s: DivFn = None  # type: ignore[assignment]
     rem_s: RemFn = None  # type: ignore[assignment]
+    cmp_eq: CmpBinFn = None  # type: ignore[assignment]
+    cmp_ne: CmpBinFn = None  # type: ignore[assignment]
+    cmp_lt_s: CmpBinFn = None  # type: ignore[assignment]
+    cmp_gt_s: CmpBinFn = None  # type: ignore[assignment]
+    cmp_le_s: CmpBinFn = None  # type: ignore[assignment]
+    cmp_ge_s: CmpBinFn = None  # type: ignore[assignment]
+    eqz: CmpUnaryFn = None  # type: ignore[assignment]
+
+    def cmp(self, op: int) -> Optional[CmpBinFn]:
+        """Resolve an OP_* opcode to the matching binary-cmp primitive.
+
+        Returns ``None`` if the relevant field is not wired — caller
+        raises :class:`SymbolicOpNotSupported`.
+        """
+        return {
+            isa.OP_EQ: self.cmp_eq,
+            isa.OP_NE: self.cmp_ne,
+            isa.OP_LT_S: self.cmp_lt_s,
+            isa.OP_GT_S: self.cmp_gt_s,
+            isa.OP_LE_S: self.cmp_le_s,
+            isa.OP_GE_S: self.cmp_ge_s,
+        }.get(op)
 
 
 DEFAULT_ARITHMETIC_OPS = ArithmeticOps(
@@ -814,6 +898,13 @@ DEFAULT_ARITHMETIC_OPS = ArithmeticOps(
     mul=lambda a, b: a * b,
     div_s=lambda a, b: RationalPoly(num=a, denom=b),
     rem_s=lambda a, b: SymbolicRemainder(num=a, denom=b),
+    cmp_eq=lambda a, b: IndicatorPoly(poly=a - b, relation=REL_EQ),
+    cmp_ne=lambda a, b: IndicatorPoly(poly=a - b, relation=REL_NE),
+    cmp_lt_s=lambda a, b: IndicatorPoly(poly=a - b, relation=REL_LT),
+    cmp_gt_s=lambda a, b: IndicatorPoly(poly=a - b, relation=REL_GT),
+    cmp_le_s=lambda a, b: IndicatorPoly(poly=a - b, relation=REL_LE),
+    cmp_ge_s=lambda a, b: IndicatorPoly(poly=a - b, relation=REL_GE),
+    eqz=lambda a: IndicatorPoly(poly=a, relation=REL_EQ),
 )
 
 
@@ -833,7 +924,18 @@ def _as_concrete_int(p: "RationalStackValue") -> Optional[int]:
     subsequent JZ/JNZ is out of scope for issue #75, so return ``None``
     and let the caller fall into the symbolic-cond path (which will then
     raise when it tries to wrap the value in a Guard).
+
+    :class:`IndicatorPoly` *can* collapse: when its inner ``poly`` is
+    concrete, the indicator evaluates to 0 or 1 deterministically and
+    JZ/JNZ should follow the branch without forking. Issue #76 needs this
+    so ``compare_lt_s(3, 5)`` (concrete inputs) collapses straight to
+    ``1`` even when consumed by a later branch.
     """
+    if isinstance(p, IndicatorPoly):
+        inner = _as_concrete_int(p.poly)
+        if inner is None:
+            return None
+        return 1 if _relation_holds(p.relation, inner) else 0
     if not isinstance(p, Poly):
         return None
     if not p.terms:
@@ -904,7 +1006,48 @@ class ForkingResult:
 
 
 def _eq_guard(p: Poly, eq_zero: bool) -> Guard:
-    return Guard(poly=p, eq_zero=eq_zero)
+    """Backwards-compat shim: build an EQ/NE guard from a bool flag.
+
+    Pre-#76 callers built guards with ``eq_zero=True/False``. New code
+    should construct :class:`Guard` with the relation directly.
+    """
+    return Guard(poly=p, relation=REL_EQ if eq_zero else REL_NE)
+
+
+def _branch_guards(cond: "RationalStackValue", op: int) -> Tuple[Guard, Guard]:
+    """Build (take_guard, skip_guard) for a JZ/JNZ on a symbolic ``cond``.
+
+    For a plain :class:`Poly` cond, JZ takes when ``cond == 0`` (skip
+    when ``cond != 0``); JNZ flips. For an :class:`IndicatorPoly` cond
+    with ``(poly, R)``, "cond == 0" ⇔ "``poly`` does NOT satisfy R" ⇔
+    "``poly (negate R) 0``", so we hoist the comparison's polynomial
+    and relation into the guard rather than wrapping the indicator
+    inside one — that way the resulting :class:`GuardedPoly` carries
+    LT/LE/GT/GE guards directly and matches the semantics the catalog
+    needs to render with the right ``<``/``<=``/``>``/``>=`` symbols.
+
+    Raises :class:`SymbolicOpNotSupported` for cond types we can't gate
+    on (RationalPoly / SymbolicRemainder — DIV_S/REM_S past JZ/JNZ
+    isn't in scope yet).
+    """
+    if isinstance(cond, IndicatorPoly):
+        # cond == 0  ⇔  not (poly R 0)  ⇔  poly (negate R) 0
+        zero_relation = _NEGATE_REL[cond.relation]
+        nonzero_relation = cond.relation
+        zero_guard = Guard(poly=cond.poly, relation=zero_relation)
+        nonzero_guard = Guard(poly=cond.poly, relation=nonzero_relation)
+    elif isinstance(cond, Poly):
+        zero_guard = Guard(poly=cond, relation=REL_EQ)
+        nonzero_guard = Guard(poly=cond, relation=REL_NE)
+    else:
+        raise SymbolicOpNotSupported(
+            f"JZ/JNZ on a {type(cond).__name__} cond is out of scope; "
+            "branching past DIV_S/REM_S is a follow-up"
+        )
+    # JZ: take when cond == 0. JNZ: take when cond != 0.
+    if op == isa.OP_JZ:
+        return zero_guard, nonzero_guard
+    return nonzero_guard, zero_guard
 
 
 def run_forking(prog: List[isa.Instruction], *,
@@ -1049,11 +1192,10 @@ def run_forking(prog: List[isa.Instruction], *,
                     break
                 new_visited = path.visited_branches | {site}
 
-                eq_guard = _eq_guard(cond, eq_zero=True)
-                ne_guard = _eq_guard(cond, eq_zero=False)
-                # JZ: take when cond == 0. JNZ: take when cond != 0.
-                take_guard = eq_guard if op == isa.OP_JZ else ne_guard
-                skip_guard = ne_guard if op == isa.OP_JZ else eq_guard
+                # _branch_guards understands both bare-Poly and
+                # IndicatorPoly conds — for the latter it hoists the
+                # comparison's relation directly into the guards.
+                take_guard, skip_guard = _branch_guards(cond, op)
 
                 take_path = path.with_(
                     pc=target,
@@ -1213,6 +1355,32 @@ def _apply_poly_op(path: _Path, instr: isa.Instruction,
                 "arithmetic_ops.rem_s is not wired; pass a rem_s primitive"
             )
         stack.append(arithmetic_ops.rem_s(a, b))
+    elif op in _CMP_BIN_OPS:
+        b = _pop(); a = _pop()
+        if not isinstance(a, Poly) or not isinstance(b, Poly):
+            raise SymbolicOpNotSupported(
+                f"{isa.OP_NAMES[op]} on non-Poly stack entries is out "
+                "of scope (composition past one DIV_S/REM_S/comparison "
+                "is a follow-up)"
+            )
+        cmp_fn = arithmetic_ops.cmp(op)
+        if cmp_fn is None:
+            raise SymbolicOpNotSupported(
+                f"arithmetic_ops.cmp({isa.OP_NAMES[op]}) is not wired"
+            )
+        stack.append(cmp_fn(a, b))
+    elif op == isa.OP_EQZ:
+        a = _pop()
+        if not isinstance(a, Poly):
+            raise SymbolicOpNotSupported(
+                "EQZ on non-Poly stack entries is out of scope "
+                "(composition past one DIV_S/REM_S/comparison is a follow-up)"
+            )
+        if arithmetic_ops.eqz is None:
+            raise SymbolicOpNotSupported(
+                "arithmetic_ops.eqz is not wired; pass an eqz primitive"
+            )
+        stack.append(arithmetic_ops.eqz(a))
     elif op == isa.OP_SWAP:
         if len(stack) < 2:
             raise SymbolicStackUnderflow(f"swap needs 2 entries at pc={path.pc}")
@@ -1281,6 +1449,9 @@ def collapse_report(prog: List[isa.Instruction], *,
 
 __all__ = [
     "Poly",
+    "RationalPoly",
+    "SymbolicRemainder",
+    "IndicatorPoly",
     "Guard",
     "GuardedPoly",
     "SymbolicResult",
@@ -1293,6 +1464,7 @@ __all__ = [
     "DEFAULT_ARITHMETIC_OPS",
     "DEFAULT_MAX_PATHS",
     "DEFAULT_MAX_STEPS",
+    "REL_EQ", "REL_NE", "REL_LT", "REL_LE", "REL_GT", "REL_GE",
     "run_symbolic",
     "run_forking",
     "collapse_report",

--- a/symbolic_programs_catalog.py
+++ b/symbolic_programs_catalog.py
@@ -39,11 +39,14 @@ from symbolic_executor import (
     ForkingResult,
     Guard,
     GuardedPoly,
+    IndicatorPoly,
     Poly,
     RationalPoly,
     SymbolicOpNotSupported,
     SymbolicRemainder,
     SymbolicStackUnderflow,
+    _REL_SYMBOL,
+    _relation_holds,
     run_forking,
     run_symbolic,
 )
@@ -104,6 +107,10 @@ _POLY_OPS = {
     isa.OP_ADD, isa.OP_SUB, isa.OP_MUL,
     isa.OP_DIV_S, isa.OP_REM_S,
     isa.OP_SWAP, isa.OP_OVER, isa.OP_ROT, isa.OP_NOP,
+    # Comparisons (issue #76) — collapse to IndicatorPoly tops and
+    # hoist relations into Guards when consumed by JZ/JNZ.
+    isa.OP_EQZ, isa.OP_EQ, isa.OP_NE,
+    isa.OP_LT_S, isa.OP_GT_S, isa.OP_LE_S, isa.OP_GE_S,
 }
 # Control flow — handled by the forking executor (issue #70).
 _BRANCH_OPS = {isa.OP_JZ, isa.OP_JNZ}
@@ -130,6 +137,10 @@ class ClassificationResult:
     # Rational tops (issue #75) — present when the program ends on a single
     # DIV_S (RationalPoly) or REM_S (SymbolicRemainder).
     rational: Optional[Any] = None        # Union[RationalPoly, SymbolicRemainder]
+    # Indicator tops (issue #76) — present when the program ends on a
+    # comparison (EQZ/EQ/NE/LT_S/LE_S/GT_S/GE_S) with an unconsumed
+    # IndicatorPoly on top of the stack.
+    indicator: Optional[IndicatorPoly] = None
     n_heads: int = 0
     bindings: Dict[int, int] = field(default_factory=dict)
     n_cases: int = 0                       # number of cases in guarded output
@@ -176,6 +187,11 @@ def classify_program(prog) -> ClassificationResult:
         return ClassificationResult(status=STATUS_BLOCKED_UNDERFLOW)
 
     if r_sym.status == "straight":
+        if isinstance(r_sym.top, IndicatorPoly):
+            return ClassificationResult(
+                status=STATUS_COLLAPSED, indicator=r_sym.top,
+                n_heads=r_sym.n_heads, bindings=dict(r_sym.bindings),
+            )
         if isinstance(r_sym.top, (RationalPoly, SymbolicRemainder)):
             return ClassificationResult(
                 status=STATUS_COLLAPSED, rational=r_sym.top,
@@ -301,9 +317,16 @@ def _default_catalog() -> List[CatalogEntry]:
     entries.append(CatalogEntry("native_clz(16)",       *P.make_native_clz(16)))
     entries.append(CatalogEntry("native_abs_unary(-3)", *P.make_native_abs_unary(-3)))
     entries.append(CatalogEntry("native_neg(5)",        *P.make_native_neg(5)))
+    # Comparisons (issue #76) — collapse to IndicatorPoly tops under
+    # the gated-bilinear-form treatment. These rows used to land in
+    # ``blocked_opcode``; after M2 they classify as ``collapsed``.
     entries.append(CatalogEntry(
         "compare_lt_s(3,5)",
         *P.make_compare_binary(isa.OP_LT_S, 3, 5),
+    ))
+    entries.append(CatalogEntry(
+        "compare_eqz(0)",
+        *P.make_compare_eqz(0),
     ))
     entries.append(CatalogEntry(
         "bitwise_and(12,10)",
@@ -321,7 +344,9 @@ def _default_catalog() -> List[CatalogEntry]:
     entries.append(CatalogEntry("clamp_zero(5)",     *P.make_clamp_zero(5)))
     entries.append(CatalogEntry("either_or(3,7,1)",  *P.make_either_or(3, 7, 1)))
 
-    # Still blocked — non-polynomial op.
+    # Guarded comparison + dispatch (issue #76) — GT_S followed by JZ
+    # hoists the comparison's relation into the Guard pair, producing
+    # a two-case GuardedPoly rather than blocking on the opcode.
     entries.append(CatalogEntry("native_max(3,5)", *P.make_native_max(3, 5)))
 
     return entries
@@ -369,6 +394,12 @@ class CatalogRow:
     # n_monomials fields stay ``None`` for these rows since eml-sr has no
     # division primitive; ``poly_expr`` renders the rational form.
     is_rational: bool = False
+    # Indicator top flag (issue #76) — True for programs that collapse
+    # to an IndicatorPoly (gated bilinear form: linear diff + relation
+    # gate). eml_* columns stay ``None`` since the single-operator EML
+    # family has no sign primitive; the gate lives at the FF-dispatch
+    # boundary rather than inside the polynomial.
+    is_indicator: bool = False
 
 
 def _numpy_top(np_exec: NumPyExecutor, prog) -> Optional[int]:
@@ -380,9 +411,9 @@ def _numpy_top(np_exec: NumPyExecutor, prog) -> Optional[int]:
 
 
 def _guard_to_expr(guard: Guard) -> str:
-    """Human-readable rendering of a single Guard (poly op 0)."""
-    op = "== 0" if guard.eq_zero else "!= 0"
-    return f"{poly_to_expr(guard.poly)} {op}"
+    """Human-readable rendering of a single Guard (poly relation 0)."""
+    sym = _REL_SYMBOL[guard.relation]
+    return f"{poly_to_expr(guard.poly)} {sym} 0"
 
 
 def _guards_to_expr(guards) -> str:
@@ -439,7 +470,9 @@ def run_catalog(entries: Optional[List[CatalogEntry]] = None, *,
         row.numpy_top = _numpy_top(np_exec, entry.prog)
 
         if cr.status == STATUS_COLLAPSED or cr.status == STATUS_COLLAPSED_UNROLLED:
-            if cr.rational is not None:
+            if cr.indicator is not None:
+                _fill_indicator_row(row, cr.indicator, cr.bindings, row.numpy_top)
+            elif cr.rational is not None:
                 _fill_rational_row(row, cr.rational, cr.bindings, row.numpy_top)
             elif cr.poly is not None:
                 _fill_poly_row(row, cr.poly, cr.bindings, row.numpy_top)
@@ -497,6 +530,38 @@ def _fill_rational_row(row: CatalogRow, rational,
     try:
         sym_val = rational.eval_at(bindings) if bindings else rational.eval_at({})
     except (KeyError, ValueError, ZeroDivisionError):
+        sym_val = None
+
+    if sym_val is None or numpy_top is None:
+        row.numeric_match = None
+    else:
+        row.numeric_match = (sym_val == numpy_top)
+
+
+def _fill_indicator_row(row: CatalogRow, indicator: IndicatorPoly,
+                        bindings: Dict[int, int],
+                        numpy_top: Optional[int]) -> None:
+    """Populate a CatalogRow from an IndicatorPoly top (issue #76).
+
+    ``indicator`` is a gated bilinear form: a linear ``Poly`` diff
+    (``vb - va`` for binary comparisons, the value itself for EQZ) plus a
+    relation tag. Renders as ``[poly <rel> 0]`` and evaluates via
+    ``indicator.eval_at`` so the non-polynomial gate lands at the
+    boundary. eml-sr columns stay ``None`` — the single-operator family
+    has no sign primitive; the gate lives in the FF dispatch, not the
+    polynomial algebra.
+
+    ``n_monomials`` reports the term count of the underlying linear
+    diff polynomial — a meaningful complexity proxy even without a
+    value-EML tree. ``poly_expr`` carries the full bracketed indicator.
+    """
+    row.is_indicator = True
+    row.poly_expr = repr(indicator)
+    row.n_monomials = indicator.poly.n_monomials()
+
+    try:
+        sym_val = indicator.eval_at(bindings) if bindings else indicator.eval_at({})
+    except KeyError:
         sym_val = None
 
     if sym_val is None or numpy_top is None:
@@ -582,9 +647,7 @@ def _fill_guarded_row(row: CatalogRow, guarded: GuardedPoly,
         ok = True
         for g in gs:
             gv = _eval_poly_safe(g.poly, bindings)
-            if g.eq_zero and gv != 0:
-                ok = False; break
-            if not g.eq_zero and gv == 0:
+            if not _relation_holds(g.relation, gv):
                 ok = False; break
         if not ok:
             continue

--- a/test_ff_symbolic.py
+++ b/test_ff_symbolic.py
@@ -38,8 +38,15 @@ from executor import CompiledModel, NumPyExecutor
 from isa import DIM_VALUE, program
 from symbolic_executor import (
     GuardedPoly,
+    IndicatorPoly,
     Poly,
     RationalPoly,
+    REL_EQ,
+    REL_GE,
+    REL_GT,
+    REL_LE,
+    REL_LT,
+    REL_NE,
     SymbolicRemainder,
     run_forking,
     run_symbolic,
@@ -576,6 +583,218 @@ def test_rational_catalog_rows_classify_as_collapsed():
         )
 
 
+# ─── Comparison primitives (issue #76) ────────────────────────────
+
+def test_primitives_forward_cmp():
+    """forward_cmp(ea, eb, op) returns E(0/1) matching WASM semantics.
+
+    Convention: ``ea`` is va (top of stack), ``eb`` is vb (SP-1). The
+    WASM ``LT_S`` opcode computes ``1 if vb < va``, so with va=5, vb=3
+    → ``3 < 5`` → 1.
+    """
+    cases = [
+        # (op, va, vb, expected 0/1)
+        (isa.OP_LT_S, 5, 3, 1),  # 3 < 5
+        (isa.OP_LT_S, 3, 5, 0),
+        (isa.OP_LT_S, 4, 4, 0),  # not strict
+        (isa.OP_GT_S, 3, 5, 1),  # 5 > 3
+        (isa.OP_GT_S, 5, 3, 0),
+        (isa.OP_LE_S, 4, 4, 1),  # non-strict
+        (isa.OP_LE_S, 3, 4, 0),  # 4 <= 3 → False
+        (isa.OP_GE_S, 4, 4, 1),
+        (isa.OP_EQ,   7, 7, 1),
+        (isa.OP_EQ,   7, 3, 0),
+        (isa.OP_NE,   7, 3, 1),
+        (isa.OP_NE,   4, 4, 0),
+    ]
+    for op, va, vb, expected in cases:
+        ea, eb = ff.E(va), ff.E(vb)
+        got = ff.E_inv(ff.forward_cmp(ea, eb, op))
+        _check(
+            f"forward_cmp[{isa.OP_NAMES[op]}](va={va},vb={vb})",
+            got == expected,
+            f"got {got}, expect {expected}",
+        )
+
+
+def test_primitives_forward_eqz():
+    """forward_eqz(ea) returns E(1) iff va == 0, else E(0)."""
+    for v, expected in [(0, 1), (1, 0), (-5, 0), (100, 0)]:
+        got = ff.E_inv(ff.forward_eqz(ff.E(v)))
+        _check(f"forward_eqz({v})", got == expected, f"got {got}, expect {expected}")
+
+
+def test_primitives_cmp_matrix_shapes():
+    """M_CMP extracts diff (vb - va) via a 1×(2d) linear form; M_EQZ
+    extracts va via a 1×d linear form. Both carry the non-polynomial
+    gate at the dispatch boundary, not in their weight tensor."""
+    d = ff.D_MODEL
+    _check("M_CMP shape", ff.M_CMP.shape == (1, 2 * d))
+    _check("M_EQZ shape", ff.M_EQZ.shape == (1, d))
+
+    # M_CMP: ea contributes -1 at DIM_VALUE, eb contributes +1 at d+DIM_VALUE.
+    _check("M_CMP[0, DIM_VALUE] == -1",
+           float(ff.M_CMP[0, DIM_VALUE].item()) == -1.0)
+    _check("M_CMP[0, d+DIM_VALUE] == +1",
+           float(ff.M_CMP[0, d + DIM_VALUE].item()) == 1.0)
+    nonzero_cmp = (ff.M_CMP != 0).sum().item()
+    _check("M_CMP has exactly 2 nonzeros", nonzero_cmp == 2)
+
+    # M_EQZ: single +1 at DIM_VALUE.
+    _check("M_EQZ[0, DIM_VALUE] == 1",
+           float(ff.M_EQZ[0, DIM_VALUE].item()) == 1.0)
+    nonzero_eqz = (ff.M_EQZ != 0).sum().item()
+    _check("M_EQZ has exactly 1 nonzero", nonzero_eqz == 1)
+
+
+def test_symbolic_comparison_primitives():
+    """symbolic_cmp / symbolic_eqz return IndicatorPoly with the right
+    diff polynomial and relation tag."""
+    x0, x1 = Poly.variable(0), Poly.variable(1)
+
+    pairs = [
+        (isa.OP_LT_S, REL_LT),
+        (isa.OP_GT_S, REL_GT),
+        (isa.OP_LE_S, REL_LE),
+        (isa.OP_GE_S, REL_GE),
+        (isa.OP_EQ,   REL_EQ),
+        (isa.OP_NE,   REL_NE),
+    ]
+    for op, expected_rel in pairs:
+        # symbolic_cmp(pa, pb) — pa=top=x0, pb=SP-1=x1 → diff = pb - pa = x1 - x0.
+        ind = ff.symbolic_cmp(x0, x1, op)
+        _check(f"symbolic_cmp[{isa.OP_NAMES[op]}] type",
+               isinstance(ind, IndicatorPoly))
+        _check(f"symbolic_cmp[{isa.OP_NAMES[op]}] relation",
+               ind.relation == expected_rel,
+               f"got {ind.relation}, expect {expected_rel}")
+        _check(f"symbolic_cmp[{isa.OP_NAMES[op]}] poly",
+               ind.poly == (x1 - x0), f"got {ind.poly!r}")
+
+    ind_eqz = ff.symbolic_eqz(x0)
+    _check("symbolic_eqz type", isinstance(ind_eqz, IndicatorPoly))
+    _check("symbolic_eqz relation", ind_eqz.relation == REL_EQ)
+    _check("symbolic_eqz poly == x0", ind_eqz.poly == x0)
+
+
+def test_equivalence_comparison_structural():
+    """forward_symbolic on comparison programs produces the same
+    IndicatorPoly the symbolic executor emits. Structural equality on
+    both the underlying poly and the relation tag."""
+    model = CompiledModel()
+    ops = [isa.OP_LT_S, isa.OP_GT_S, isa.OP_LE_S, isa.OP_GE_S,
+           isa.OP_EQ, isa.OP_NE]
+    for op in ops:
+        prog = program(("PUSH", 3), ("PUSH", 5),
+                       (isa.OP_NAMES[op],), ("HALT",))
+        sym = run_symbolic(prog)
+        fs = model.forward_symbolic(prog)
+        _check(
+            f"cmp.struct.type[{isa.OP_NAMES[op]}]",
+            isinstance(sym.top, IndicatorPoly)
+            and isinstance(fs.top, IndicatorPoly),
+            f"sym={type(sym.top).__name__}, ff={type(fs.top).__name__}",
+        )
+        _check(
+            f"cmp.struct.poly[{isa.OP_NAMES[op]}]",
+            sym.top.poly == fs.top.poly,
+            f"sym.poly={sym.top.poly!r} ff.poly={fs.top.poly!r}",
+        )
+        _check(
+            f"cmp.struct.rel[{isa.OP_NAMES[op]}]",
+            sym.top.relation == fs.top.relation,
+            f"sym.rel={sym.top.relation} ff.rel={fs.top.relation}",
+        )
+
+
+def test_equivalence_eqz_structural():
+    """forward_symbolic on EQZ matches run_symbolic.top structurally."""
+    model = CompiledModel()
+    prog = program(("PUSH", 0), ("EQZ",), ("HALT",))
+    sym = run_symbolic(prog)
+    fs = model.forward_symbolic(prog)
+    _check("eqz.struct.type",
+           isinstance(sym.top, IndicatorPoly) and isinstance(fs.top, IndicatorPoly))
+    _check("eqz.struct.poly", sym.top.poly == fs.top.poly)
+    _check("eqz.struct.rel", sym.top.relation == fs.top.relation == REL_EQ)
+
+
+def test_equivalence_comparison_numeric():
+    """Three-way check: sym.eval_at == NumPy top == TorchExecutor top.
+
+    Covers the WASM convention (``LT_S`` returns ``1 if vb < va``) across
+    every signed comparison plus EQZ, on inputs spanning the comparison's
+    {<, =, >} (or {=0, ≠0}) regions.
+    """
+    from executor import TorchExecutor
+    model = CompiledModel()
+    np_exec = NumPyExecutor()
+    torch_exec = TorchExecutor(model)
+
+    binary_cases = [
+        (isa.OP_LT_S, (3, 5)), (isa.OP_LT_S, (5, 3)), (isa.OP_LT_S, (4, 4)),
+        (isa.OP_GT_S, (3, 5)), (isa.OP_LE_S, (4, 4)), (isa.OP_GE_S, (7, 2)),
+        (isa.OP_EQ,   (7, 7)), (isa.OP_NE,   (3, 5)),
+    ]
+    for op, (a, b) in binary_cases:
+        prog = [
+            isa.Instruction(isa.OP_PUSH, a),
+            isa.Instruction(isa.OP_PUSH, b),
+            isa.Instruction(op),
+            isa.Instruction(isa.OP_HALT),
+        ]
+        sym = run_symbolic(prog)
+        sym_val = sym.top.eval_at(sym.bindings)
+        np_top = np_exec.execute(prog).steps[-1].top
+        t_top = torch_exec.execute(prog).steps[-1].top
+        _check(
+            f"cmp.numeric[{isa.OP_NAMES[op]}({a},{b})]",
+            sym_val == np_top == t_top,
+            f"sym={sym_val} np={np_top} torch={t_top}",
+        )
+
+    for a in [-3, -1, 0, 1, 5]:
+        prog = [
+            isa.Instruction(isa.OP_PUSH, a),
+            isa.Instruction(isa.OP_EQZ),
+            isa.Instruction(isa.OP_HALT),
+        ]
+        sym = run_symbolic(prog)
+        sym_val = sym.top.eval_at(sym.bindings)
+        np_top = np_exec.execute(prog).steps[-1].top
+        t_top = torch_exec.execute(prog).steps[-1].top
+        _check(
+            f"eqz.numeric({a})",
+            sym_val == np_top == t_top,
+            f"sym={sym_val} np={np_top} torch={t_top}",
+        )
+
+
+def test_native_max_three_way_numeric():
+    """native_max demonstrates the full gated path end-to-end: GT_S →
+    IndicatorPoly → JZ hoists relation into Guard pair → GuardedPoly
+    dispatch. Symbolic eval, NumPy exec, and TorchExecutor must all agree
+    on the computed max at the catalog's concrete inputs."""
+    from executor import TorchExecutor
+    import programs as P
+    model = CompiledModel()
+    np_exec = NumPyExecutor()
+    torch_exec = TorchExecutor(model)
+
+    for a, b in [(3, 5), (7, 2), (4, 4)]:
+        prog, expected = P.make_native_max(a, b)
+        sym = run_forking(prog, input_mode="symbolic")
+        assert sym.top is not None
+        sym_val = sym.top.eval_at(sym.bindings)
+        np_top = np_exec.execute(prog).steps[-1].top
+        t_top = torch_exec.execute(prog).steps[-1].top
+        _check(
+            f"native_max.numeric({a},{b})",
+            sym_val == np_top == t_top == expected,
+            f"sym={sym_val} np={np_top} torch={t_top} expected={expected}",
+        )
+
+
 # ─── Blocked-opcode handling ──────────────────────────────────────
 
 def test_blocked_opcodes():
@@ -640,6 +859,14 @@ def main():
         test_symbolic_rational_primitives,
         test_equivalence_rational,
         test_rational_catalog_rows_classify_as_collapsed,
+        test_primitives_forward_cmp,
+        test_primitives_forward_eqz,
+        test_primitives_cmp_matrix_shapes,
+        test_symbolic_comparison_primitives,
+        test_equivalence_comparison_structural,
+        test_equivalence_eqz_structural,
+        test_equivalence_comparison_numeric,
+        test_native_max_three_way_numeric,
         test_blocked_opcodes,
     ]
     print("=" * 60)

--- a/test_symbolic_executor.py
+++ b/test_symbolic_executor.py
@@ -22,10 +22,20 @@ import isa
 from executor import NumPyExecutor
 from isa import program
 from symbolic_executor import (
+    Guard,
+    GuardedPoly,
+    IndicatorPoly,
     Poly,
+    REL_EQ,
+    REL_GE,
+    REL_GT,
+    REL_LE,
+    REL_LT,
+    REL_NE,
     SymbolicOpNotSupported,
     SymbolicStackUnderflow,
     collapse_report,
+    run_forking,
     run_symbolic,
 )
 
@@ -175,6 +185,153 @@ def test_pop_underflow_raises():
         pass
     else:
         raise AssertionError("expected SymbolicStackUnderflow")
+
+
+# ─── Comparisons + IndicatorPoly (issue #76) ─────────────────────
+
+def test_indicator_poly_gates_at_boundary():
+    """IndicatorPoly.eval_at returns 0/1 by applying the relation to the
+    underlying Poly's concrete value — the non-polynomial gate lives at
+    the boundary, not inside the polynomial algebra."""
+    x, y = Poly.variable(0), Poly.variable(1)
+    diff = x - y
+    ip_lt = IndicatorPoly(poly=diff, relation=REL_LT)
+    assert ip_lt.eval_at({0: 3, 1: 5}) == 1   # 3 - 5 = -2 < 0
+    assert ip_lt.eval_at({0: 5, 1: 5}) == 0   # 0 < 0 is False
+    assert ip_lt.eval_at({0: 7, 1: 5}) == 0   # 2 < 0 is False
+
+    ip_eq = IndicatorPoly(poly=x, relation=REL_EQ)
+    assert ip_eq.eval_at({0: 0}) == 1
+    assert ip_eq.eval_at({0: 3}) == 0
+
+
+def test_comparison_ops_return_indicator_poly():
+    """Each signed comparison leaves an IndicatorPoly on top whose poly
+    is ``vb - va`` (the WASM-flavored diff, with pa=top / pb=SP-1) and
+    whose relation tags the opcode's test."""
+    cases = [
+        (isa.OP_LT_S, REL_LT),
+        (isa.OP_GT_S, REL_GT),
+        (isa.OP_LE_S, REL_LE),
+        (isa.OP_GE_S, REL_GE),
+        (isa.OP_EQ,   REL_EQ),
+        (isa.OP_NE,   REL_NE),
+    ]
+    for op, expected_rel in cases:
+        prog = [
+            isa.Instruction(isa.OP_PUSH, 3),
+            isa.Instruction(isa.OP_PUSH, 5),
+            isa.Instruction(op),
+            isa.Instruction(isa.OP_HALT),
+        ]
+        r = run_symbolic(prog)
+        assert isinstance(r.top, IndicatorPoly), op
+        assert r.top.relation == expected_rel, op
+        # pa = top = x1 (pushed second), pb = SP-1 = x0 (pushed first).
+        # Diff = pb - pa = x0 - x1.
+        assert r.top.poly == Poly({((0, 1),): 1, ((1, 1),): -1}), op
+
+
+def test_eqz_returns_indicator_with_eq_relation():
+    prog = [
+        isa.Instruction(isa.OP_PUSH, 0),
+        isa.Instruction(isa.OP_EQZ),
+        isa.Instruction(isa.OP_HALT),
+    ]
+    r = run_symbolic(prog)
+    assert isinstance(r.top, IndicatorPoly)
+    assert r.top.relation == REL_EQ
+    assert r.top.poly == Poly.variable(0)
+
+
+def test_comparison_symbolic_vs_numeric_equivalence():
+    """Every signed comparison agrees with NumPyExecutor on sample
+    inputs drawn from the {<, =, >} regions of the diff."""
+    np_exec = NumPyExecutor()
+    failures = []
+    for op in (isa.OP_LT_S, isa.OP_GT_S, isa.OP_LE_S, isa.OP_GE_S,
+               isa.OP_EQ, isa.OP_NE):
+        for a, b in [(3, 5), (5, 3), (7, 7), (-2, 4), (0, 0), (-1, 0)]:
+            prog = [
+                isa.Instruction(isa.OP_PUSH, a),
+                isa.Instruction(isa.OP_PUSH, b),
+                isa.Instruction(op),
+                isa.Instruction(isa.OP_HALT),
+            ]
+            trace = np_exec.execute(prog)
+            numeric = trace.steps[-1].top
+            r = run_symbolic(prog)
+            symbolic = r.top.eval_at(r.bindings)
+            if numeric != symbolic:
+                failures.append(
+                    f"op={isa.OP_NAMES[op]} a={a} b={b} "
+                    f"numeric={numeric} symbolic={symbolic}"
+                )
+    assert not failures, "\n  ".join(["mismatches:"] + failures)
+
+
+def test_eqz_symbolic_vs_numeric_equivalence():
+    """EQZ agrees with NumPyExecutor on inputs spanning the {=0, ≠0} split."""
+    np_exec = NumPyExecutor()
+    for a in [-3, -1, 0, 1, 5]:
+        prog = [
+            isa.Instruction(isa.OP_PUSH, a),
+            isa.Instruction(isa.OP_EQZ),
+            isa.Instruction(isa.OP_HALT),
+        ]
+        trace = np_exec.execute(prog)
+        numeric = trace.steps[-1].top
+        r = run_symbolic(prog)
+        symbolic = r.top.eval_at(r.bindings)
+        assert numeric == symbolic, (a, numeric, symbolic)
+
+
+def test_jz_on_indicator_hoists_relation_into_guards():
+    """JZ consuming an IndicatorPoly produces a two-branch fork whose
+    Guards carry the *negated* / taken relation — not an EQ wrapping."""
+    # native_max: PUSH a, PUSH b, OVER, OVER, GT_S, JZ skip, POP, HALT; skip: SWAP POP HALT
+    import programs as P
+    prog, _ = P.make_native_max(3, 5)
+    r = run_forking(prog, input_mode="symbolic")
+    assert r.status == "guarded"
+    assert isinstance(r.top, GuardedPoly)
+    assert r.top.n_cases() == 2
+    relations = {g.relation for gs, _ in r.top.cases for g in gs}
+    # GT_S test ⇒ JZ-taken branch gets LE, JZ-skipped gets GT.
+    assert relations == {REL_LE, REL_GT}
+
+
+def test_guard_eq_zero_backward_compat_property():
+    """Guard.eq_zero still reads True for REL_EQ, False for others —
+    kept as a @property shim so older tests / catalog rows don't break."""
+    p = Poly.variable(0)
+    assert Guard(poly=p, relation=REL_EQ).eq_zero is True
+    assert Guard(poly=p, relation=REL_NE).eq_zero is False
+    assert Guard(poly=p, relation=REL_LT).eq_zero is False
+    assert Guard(poly=p, relation=REL_GE).eq_zero is False
+
+
+def test_composition_past_indicator_blocked():
+    """Arithmetic composed on top of an IndicatorPoly is out of scope —
+    comparisons produce non-polynomial 0/1 values that don't round-trip
+    through Poly arithmetic. The executor must raise rather than silently
+    pretend the indicator is a Poly."""
+    prog = [
+        isa.Instruction(isa.OP_PUSH, 3),
+        isa.Instruction(isa.OP_PUSH, 5),
+        isa.Instruction(isa.OP_LT_S),
+        isa.Instruction(isa.OP_PUSH, 1),
+        isa.Instruction(isa.OP_ADD),
+        isa.Instruction(isa.OP_HALT),
+    ]
+    try:
+        run_symbolic(prog)
+    except SymbolicOpNotSupported:
+        pass
+    else:
+        raise AssertionError(
+            "expected SymbolicOpNotSupported for ADD on IndicatorPoly"
+        )
 
 
 # ─── Cross-check against NumPyExecutor ────────────────────────────

--- a/test_symbolic_programs_catalog.py
+++ b/test_symbolic_programs_catalog.py
@@ -23,7 +23,7 @@ import sys
 import isa
 from executor import NumPyExecutor
 from isa import program
-from symbolic_executor import GuardedPoly, Poly
+from symbolic_executor import GuardedPoly, IndicatorPoly, Poly, REL_EQ, REL_GT, REL_LE, REL_LT
 from symbolic_programs_catalog import (
     _EML_AVAILABLE,
     CatalogEntry,
@@ -33,6 +33,7 @@ from symbolic_programs_catalog import (
     STATUS_COLLAPSED,
     STATUS_COLLAPSED_GUARDED,
     STATUS_COLLAPSED_UNROLLED,
+    _guard_to_expr,
     classify_program,
     poly_to_expr,
     run_catalog,
@@ -157,18 +158,78 @@ def test_classify_rational_top_on_rem_s():
 
 
 def test_classify_first_blocker_wins():
-    # LT_S precedes JZ — non-polynomial opcode is reported even though
-    # control flow also appears further down.
+    # CLZ precedes JZ — non-polynomial opcode is reported even though
+    # control flow also appears further down. (LT_S no longer blocks
+    # as of issue #76 — it collapses to an IndicatorPoly.)
     prog = [
-        isa.Instruction(isa.OP_PUSH, 3),
-        isa.Instruction(isa.OP_PUSH, 5),
-        isa.Instruction(isa.OP_LT_S),
+        isa.Instruction(isa.OP_PUSH, 16),
+        isa.Instruction(isa.OP_CLZ),
         isa.Instruction(isa.OP_JZ, 99),
         isa.Instruction(isa.OP_HALT),
     ]
     cr = classify_program(prog)
     assert cr.status == "blocked_opcode"
-    assert cr.blocker == "LT_S"
+    assert cr.blocker == "CLZ"
+
+
+# ─── Comparison opcodes (issue #76) ───────────────────────────────
+
+def test_classify_compare_lt_s_collapses_to_indicator():
+    """LT_S on symbolic inputs collapses to an IndicatorPoly top."""
+    prog = [
+        isa.Instruction(isa.OP_PUSH, 3),
+        isa.Instruction(isa.OP_PUSH, 5),
+        isa.Instruction(isa.OP_LT_S),
+        isa.Instruction(isa.OP_HALT),
+    ]
+    cr = classify_program(prog)
+    assert cr.status == STATUS_COLLAPSED
+    assert cr.indicator is not None
+    assert isinstance(cr.indicator, IndicatorPoly)
+    assert cr.indicator.relation == REL_LT
+    # diff = vb - va = x0 - x1
+    assert cr.indicator.poly == Poly({((0, 1),): 1, ((1, 1),): -1})
+    assert cr.poly is None and cr.rational is None
+
+
+def test_classify_compare_eqz_collapses_to_indicator():
+    """EQZ on a symbolic input collapses to an IndicatorPoly(poly=x0, REL_EQ)."""
+    prog = [
+        isa.Instruction(isa.OP_PUSH, 0),
+        isa.Instruction(isa.OP_EQZ),
+        isa.Instruction(isa.OP_HALT),
+    ]
+    cr = classify_program(prog)
+    assert cr.status == STATUS_COLLAPSED
+    assert cr.indicator is not None
+    assert cr.indicator.relation == REL_EQ
+    assert cr.indicator.poly == Poly.variable(0)
+
+
+def test_classify_native_max_is_guarded_with_le_gt():
+    """GT_S → JZ → POP/HALT dispatch hoists the comparison's relation
+    into the Guard pair, producing a two-case GuardedPoly with LE/GT
+    guards (not EQ/NE — that was the S1 backward-compat path)."""
+    import programs as P
+    prog, expected = P.make_native_max(3, 5)
+    cr = classify_program(prog)
+    assert cr.status == STATUS_COLLAPSED_GUARDED
+    assert cr.guarded is not None
+    assert cr.n_cases == 2
+    relations = {g.relation for gs, _ in cr.guarded.cases for g in gs}
+    assert relations == {REL_LE, REL_GT}
+
+
+def test_guard_to_expr_renders_full_relation_set():
+    """Render all six relation symbols correctly."""
+    from symbolic_executor import Guard, REL_EQ, REL_NE, REL_LT, REL_LE, REL_GT, REL_GE
+    p = Poly.variable(0)
+    assert _guard_to_expr(Guard(poly=p, relation=REL_EQ)) == "x0 == 0"
+    assert _guard_to_expr(Guard(poly=p, relation=REL_NE)) == "x0 != 0"
+    assert _guard_to_expr(Guard(poly=p, relation=REL_LT)) == "x0 < 0"
+    assert _guard_to_expr(Guard(poly=p, relation=REL_LE)) == "x0 <= 0"
+    assert _guard_to_expr(Guard(poly=p, relation=REL_GT)) == "x0 > 0"
+    assert _guard_to_expr(Guard(poly=p, relation=REL_GE)) == "x0 >= 0"
 
 
 # ─── run_catalog — end-to-end pipeline ────────────────────────────
@@ -178,7 +239,10 @@ def test_run_catalog_default_has_collapsed_and_blocked():
     n_collapsed = sum(1 for r in rows if r.status == "collapsed")
     n_blocked = sum(1 for r in rows if r.status.startswith("blocked"))
     assert n_collapsed >= 10, f"expected ≥10 collapsed rows, got {n_collapsed}"
-    assert n_blocked >= 5, f"expected ≥5 blocked rows, got {n_blocked}"
+    # Floor dropped from ≥5 to ≥4 in issue #76: compare_lt_s + native_max
+    # (and compare_eqz on first landing) now classify as collapsed /
+    # collapsed_guarded rather than blocked_opcode.
+    assert n_blocked >= 4, f"expected ≥4 blocked rows, got {n_blocked}"
 
 
 def test_run_catalog_collapsed_rows_numeric_match():
@@ -226,6 +290,39 @@ def test_run_catalog_pins_guarded_rows():
     assert rows["either_or(3,7,1)"].n_cases == 2
     assert rows["either_or(3,7,1)"].numpy_top == 7
     assert rows["either_or(3,7,1)"].numeric_match is True
+
+
+def test_run_catalog_pins_comparison_rows():
+    """Issue #76 pins: comparison rows move from blocked_opcode to
+    collapsed (LT_S, EQZ) / collapsed_guarded (native_max with GT_S+JZ
+    dispatch). All three numeric-match at the catalog's concrete inputs.
+    """
+    rows = {r.name: r for r in run_catalog()}
+
+    r = rows["compare_lt_s(3,5)"]
+    assert r.status == STATUS_COLLAPSED
+    assert r.is_indicator is True
+    assert r.poly_expr == "[x0 - x1 < 0]"
+    assert r.numpy_top == 1  # 3 < 5 → 1
+    assert r.numeric_match is True
+    # eml-sr has no sign primitive — indicator rows skip the eml columns.
+    assert r.eml_size is None and r.eml_depth is None
+
+    r = rows["compare_eqz(0)"]
+    assert r.status == STATUS_COLLAPSED
+    assert r.is_indicator is True
+    assert r.poly_expr == "[x0 == 0]"
+    assert r.numpy_top == 1  # 0 == 0 → 1
+    assert r.numeric_match is True
+
+    r = rows["native_max(3,5)"]
+    assert r.status == STATUS_COLLAPSED_GUARDED
+    assert r.n_cases == 2
+    assert r.numpy_top == 5
+    assert r.numeric_match is True
+    # Both branches render with LE / GT relation symbols.
+    joined = " ; ".join(r.case_exprs or [])
+    assert " <= 0" in joined and " > 0" in joined
 
 
 def test_run_catalog_pins_unrolled_rows():


### PR DESCRIPTION
## Summary

Implements issue #76 (M2): piecewise bilinear forms for WASM-style signed comparisons (`LT_S / GT_S / LE_S / GE_S / EQ / NE / EQZ`). The three-stage story mirrors the rational extension from #75 — keep the polynomial fragment linear, push the non-polynomial gate to the boundary, make the gate first-class.

## What changed

### Symbolic executor (`symbolic_executor.py`)

- New `IndicatorPoly` sibling type (mirrors `RationalPoly`): `Poly` diff + relation tag, with `_relation_holds` firing only at `eval_at`.
- `Guard` broadens from `eq_zero: bool` → `relation: str` (one of six: `REL_EQ / NE / LT / LE / GT / GE`); `eq_zero` kept as a `@property` shim so pre-#76 code and tests keep working.
- All seven comparison opcodes emit `IndicatorPoly` tops. `JZ / JNZ` consuming an `IndicatorPoly` *hoists* its relation directly into the `Guard` pair — so `native_max` now collapses to a clean two-case `Guarded[{x0-x1 ≤ 0} → x1; {x0-x1 > 0} → x0]` rather than a redundantly-wrapped indicator.
- Composition past an `IndicatorPoly` raises `SymbolicOpNotSupported` (deliberate — same non-goal shape as rationals).

### FF bilinear dispatch (`ff_symbolic.py`)

- `M_CMP` (`1 × 2d`, 2 nonzeros): diff extractor `vb − va`.
- `M_EQZ` (`1 × d`, 1 nonzero): value extractor `va`.
- `forward_cmp(ea, eb, op)` / `forward_eqz(ea)` apply the linear extraction then gate at the boundary, returning `E(0/1)`.
- `symbolic_cmp` / `symbolic_eqz` return `IndicatorPoly(pb - pa, OP_RELATION[op])` / `IndicatorPoly(pa, REL_EQ)`.
- Total non-zero weight budget: +3, bringing the running total (ADD/SUB/MUL/DIV_S/REM_S/CMP/EQZ) to **12** non-zero entries across 7 matrices.

### Numeric FF wiring (`executor.py`)

- The 7 comparison opcodes in `CompiledModel.forward`'s nonlinear path now route through `ff_symbolic.forward_cmp` / `forward_eqz` (previously inline CPython). Unsigned variants (`LT_U`/…) still alias their signed counterparts.

### Catalog (`symbolic_programs_catalog.py`)

- Three rows move off `blocked_opcode`:
  - `compare_lt_s(3,5)` → **collapsed** `[x0 - x1 < 0]`, numpy_top = 1, match ✓
  - `compare_eqz(0)` → **collapsed** `[x0 == 0]`, numpy_top = 1, match ✓ _(new catalog entry)_
  - `native_max(3,5)` → **collapsed_guarded** `Guarded[{x0-x1 ≤ 0} → x1; {x0-x1 > 0} → x0]`, numpy_top = 5, match ✓
- `ClassificationResult.indicator`, `CatalogRow.is_indicator`, `_fill_indicator_row` added (analog of the rational path).
- `_guard_to_expr` now renders the full six-relation symbol set (`==`, `!=`, `<`, `<=`, `>`, `>=`).

### Tests

- **`test_symbolic_executor.py`** (+157 lines): `IndicatorPoly.eval_at` gate, per-opcode relation + diff, symbolic-vs-numeric equivalence across 6 ops × 6 sign-varied inputs, EQZ parity across `{=0, ≠0}`, JZ-hoist on `native_max`, `Guard.eq_zero` backward-compat shim, composition-past-indicator blocked.
- **`test_ff_symbolic.py`** (+227 lines): `forward_cmp` / `forward_eqz` numeric checks, matrix shape + non-zero pins, `symbolic_cmp` / `symbolic_eqz` type + relation + poly, structural equivalence `CompiledModel ≡ run_symbolic`, three-way equivalence `sym == NumPy == Torch` on 8 binary + 5 unary cases, `native_max` end-to-end at three inputs.
- **`test_symbolic_programs_catalog.py`** (+104 lines / -7): first-blocker-wins retargeted from LT_S (no longer blocks) → CLZ; per-row pins for the three reclassified rows; relation-symbol rendering; blocked-row floor lowered 5 → 4.

### Design note (`dev/ff_symbolic_equivalence.md`)

- New "Gated bilinear extension (issue #76)" section: the three moves (IndicatorPoly sibling type, Guard broadening, M_CMP/M_EQZ + relation gate), the equivalence theorem, catalog impact, composition non-goal.
- New "Refactor plan: migrating S1 guards to sign indicators" section: documents that the in-place `Guard.relation` refactor is done; S1 catalog rows (`select_by_sign`, `clamp_zero`, `either_or`) keep their `EQ / NE` guards because they fork on plain `Poly` (not an `IndicatorPoly`); future opportunity for guard canonicalisation using the six-relation algebra.
- "What this issue does not prove" list updated — comparisons are no longer out of scope.

## Acceptance criteria (issue #76)

- [x] `Poly` sibling `IndicatorPoly` supports sign-indicator semantics.
- [x] `ff_symbolic` gains gated bilinear forms (`forward_cmp` / `forward_eqz`) for every comparison op.
- [x] Catalog rows for comparisons move from `blocked_opcode` to `collapsed` / `collapsed_guarded`.
- [x] Three-way equivalence (sym ≡ numeric ≡ eml) holds per new row. _(eml column stays `–` — `eml(x, y) = exp(x) − ln(y)` has no sign primitive; cross-check is sym ≡ NumPy ≡ Torch, which is the analogous three-way claim for gated forms.)_
- [x] Design note updated with the "Gated bilinear extension" and "Refactor plan" sections.
- [x] Unlocks `compare_lt_s`, `compare_eqz`, `native_max`, + all signed WASM comparison opcodes.

## Test plan

- [x] `python -m pytest test_symbolic_executor.py test_symbolic_programs_catalog.py` — **61 passed**
- [x] `python test_ff_symbolic.py` — **All checks passed** (including 3-way numeric equivalence on 8 binary + 5 EQZ + 3 native_max cases)
- [x] `python symbolic_programs_catalog.py` — report renders cleanly; 19 collapsed / 4 guarded / 4 unrolled / 4 blocked-by-opcode
- [x] `compare_lt_s(3,5)` → `[x0 - x1 < 0]` with match ✓
- [x] `compare_eqz(0)` → `[x0 == 0]` with match ✓
- [x] `native_max(3,5)` → `Guarded[…]` with match ✓

Closes #76.