### PR TITLE
M4: Honest i32 wrap semantics via ModPoly (closes #78)

### DIFF
--- a/dev/ff_symbolic_equivalence.md
+++ b/dev/ff_symbolic_equivalence.md
@@ -395,7 +395,7 @@ assertion that reads guards via the backward-compat property).
 The bilinear form computes over `ℤ` — no `& MASK32`. The issue framed
 this as Option (a): "produce a polynomial over `ℤ`; add a `range_check`
 that asserts no wrap would have occurred on the catalog inputs." That's
-the route taken here.
+the route taken in #69 and it still holds.
 
 `CompiledModel.forward` still applies the mask *after* the bilinear form
 so that `NumPyExecutor` parity holds bit-for-bit (`test_consolidated.py`
@@ -410,9 +410,123 @@ however, is stated pre-mask:
 Every catalog program satisfies the range check; the largest unmasked
 value is `factorial(10) = 3,628,800`, well inside i32.
 
-Option (b) — carry `mod 2^32` through the polynomial algebra — is
-strictly heavier (polynomials over `ℤ/2^32ℤ` have gcd factoring issues
-and no division) and is deliberately out of scope.
+Issue #78 landed Option (b) as a sibling artefact — see the next
+section. Option (a) remains the "clean catalog" interpretation; Option
+(b) is the honest wrap theorem that also covers overflow-probing
+inputs.
+
+## Wrap-aware extension (issue #78 option (b))
+
+Issue #69 decided that carrying `mod 2³²` through the algebra was out
+of scope and pinned the range via :func:`ff_symbolic.range_check`
+instead (Option (a)). Issue #78's motivating concern is that the
+resulting theorem is *only* tested in the range where both sides agree,
+so "a bug in either direction would pass silently". Option (b) closes
+that gap — not by replacing Option (a), but by adding a sibling
+polynomial ring whose structural equality mirrors the FF layer's
+`& MASK32` step in the algebra itself.
+
+### `ModPoly`: polynomials over ℤ / 2³²
+
+`symbolic_executor.ModPoly` is a sibling of :class:`Poly`. Same canonical
+form (monomial dict, zero-coefficient terms dropped), same arithmetic
+surface (`+`, `-`, `*`, `__neg__`) — the one difference is that every
+operation reduces coefficients modulo 2³² via `__post_init__`. That
+reduction *is* the `& MASK32` step, now visible in one place instead of
+as a silent boundary fact.
+
+Key operations:
+
+```python
+ModPoly.from_poly(p)              # lift a pure-integer Poly
+mp1 + mp2, mp1 - mp2, mp1 * mp2   # closed under the ring ops
+mp.eval_at(bindings)              # unsigned u32 int in [0, 2³²)
+mp.eval_at_signed(bindings)       # signed i32 int in [-2³¹, 2³¹)
+```
+
+Non-goal: division. ℤ/2³² is a ring with zero divisors (`2 · 2³¹ = 0`),
+so no `a / b` is well-defined. That's fine — DIV_S / REM_S already live
+in their own wrapper (`RationalPoly` / `SymbolicRemainder`) whose
+boundary evaluator handles truncation and wrap together.
+
+### The mod-2³² driver
+
+`ff_symbolic.evaluate_program_mod(prog)` mirrors
+:func:`evaluate_program`, swapping `Poly` for `ModPoly` at every stack
+site. The arithmetic primitives are `symbolic_add_mod` / `_sub_mod` /
+`_mul_mod` — the ModPoly interpretation of the same operator tree
+`M_ADD` / `M_SUB` / `B_MUL` realise over floats.
+
+Scope is strictly narrower than :func:`evaluate_program`:
+`{ADD, SUB, MUL, PUSH, POP, DUP, NOP, SWAP, OVER, ROT, HALT}`.
+Comparisons, rationals, and bitwise ops raise
+`BlockedOpcodeForSymbolic` — those fragments have their own boundary
+wrap (`IndicatorPoly` / `RationalPoly` / `BitVec`) that already
+corresponds to the correct semantics; lifting them into ℤ/2³² would
+duplicate that logic.
+
+### Equivalence theorem (Option (b))
+
+> **Structural over ℤ/2³²:** For every collapsed catalog program P
+> whose `run_symbolic(P).top` is a plain `Poly`,
+>
+> ```python
+> ModPoly.from_poly(run_symbolic(P).top) == evaluate_program_mod(P).top
+> ```
+>
+> as dict-equality on canonical coefficient maps in [0, 2³²). 15/15
+> pure-Poly collapsed rows satisfy this
+> (`test_modpoly_catalog_structural`).
+
+The proof is a one-liner: the ring homomorphism ℤ → ℤ/2³² commutes
+with every primitive operation the two drivers apply, so lifting the
+inputs (each PUSH produces a ModPoly variable instead of a Poly
+variable) and doing the same operations produces the lifted result.
+`test_modpoly_homomorphism_on_catalog` asserts the commutation directly
+— `ModPoly.from_poly(evaluate_program.top) == evaluate_program_mod.top`.
+
+> **Numeric bit-for-bit:** For every collapsed row,
+>
+> ```python
+> evaluate_program_mod(P).top.eval_at(bindings) \
+>   == NumPyExecutor(P).top & 0xFFFFFFFF
+> ```
+>
+> No range check needed — the two sides agree in ℤ/2³² **by
+> construction**, not just on in-range inputs
+> (`test_modpoly_catalog_numeric`).
+
+### Overflow-stress coverage
+
+`test_modpoly_overflow_stress` exercises four programs where the ℤ
+result either doesn't fit signed i32 or exceeds `2³²` entirely:
+
+| Program                         | ℤ value          | ℤ/2³² value    | Native (NumPy) | Notes                                            |
+| ------------------------------- | ---------------: | -------------: | -------------: | ------------------------------------------------ |
+| `PUSH 46341; DUP; MUL`          |    2,147,488,281 |  2,147,488,281 |  2,147,488,281 | overflows signed i32 (I32_MAX = 2,147,483,647) |
+| `PUSH 100_000; PUSH 100_000; MUL` |  10,000,000,000 |  1,410,065,408 |  1,410,065,408 | exceeds u32; ℤ disagrees with native, ℤ/2³² matches |
+| `PUSH 65536; DUP; MUL`          |   4,294,967,296 |              0 |              0 | zero-divisor witness: `2¹⁶ · 2¹⁶ = 0 (mod 2³²)`  |
+| `PUSH I32_MAX; PUSH 2; ADD`     |    2,147,483,649 |  2,147,483,649 |  2,147,483,649 | signed overflow (reads as `I32_MIN + 1` signed)  |
+
+The 100k × 100k case is the one Option (a) could not cover: its
+`range_check` rejects the value (so the equivalence-under-range claim
+doesn't apply), but the program is still a valid catalog-style
+arithmetic trace. ModPoly makes the native-match provable for *any*
+i32-representable inputs, not just the ones that happen to stay below
+`I32_MAX`.
+
+### What Option (b) deliberately doesn't change
+
+- **Option (a) survives.** `range_check`, the equivalence theorem over
+  ℤ, the writeup above — all still accurate for the catalog. They're
+  the cleanest statement when inputs are known to be in range.
+- **`forward_symbolic` stays over ℤ.** The mod-2³² path is an
+  independent driver (`evaluate_program_mod`); the existing Poly-based
+  API is unchanged. No existing test regresses.
+- **Non-polynomial fragments stay in their wrappers.** Rationals,
+  indicators, bit-vectors already wrap correctly at their boundary
+  evaluators; lifting them into a ℤ/2³² polynomial would either
+  duplicate or contradict their semantics. Out of scope.
 
 ### What this issue does **not** prove
 

--- a/ff_symbolic.py
+++ b/ff_symbolic.py
@@ -156,6 +156,7 @@ from symbolic_executor import (
     BitVec,
     ForkingResult,
     IndicatorPoly,
+    ModPoly,
     Poly,
     RationalPoly,
     RationalStackValue,
@@ -964,6 +965,152 @@ def evaluate_program(prog) -> SymbolicForwardResult:
                                  n_heads=n_heads, bindings=bindings)
 
 
+# ─── Mod-2³² symbolic primitives (issue #78 option (b)) ───────────
+#
+# ``symbolic_add`` / ``symbolic_sub`` / ``symbolic_mul`` above realise the
+# FF bilinear form over ℤ — the equivalence theorem from issue #69 is
+# structural over ℤ under a :func:`range_check` assumption. Issue #78
+# adds a sibling fragment that carries the i32 wrap semantics through
+# the algebra itself: the same spec (M_ADD / M_SUB / B_MUL) interpreted
+# over :class:`ModPoly` closes the ``& MASK32`` gap symbolically.
+#
+# Concretely: ``forward_add / forward_sub / forward_mul`` on float tensors
+# compute ``(va + vb) & MASK32`` / etc. — the mask lives *outside* the
+# bilinear form in :meth:`executor.CompiledModel.forward`. On the
+# symbolic side, ``symbolic_add_mod`` / etc. evaluate the same operator
+# tree over :class:`ModPoly`, whose ``__post_init__`` reduces coefficients
+# modulo 2³² after every step. That reduction is the same ``& MASK32``,
+# now visible as a single line of algebra instead of a numeric-only
+# boundary fact.
+#
+# This is the "real work" option from issue #78 (as opposed to Option (a),
+# which pins :func:`range_check` and stops). It's orthogonal to the
+# Poly-over-ℤ fragment: both continue to work; ``ModPoly`` is a proof
+# artefact for the wrap case, not a replacement.
+
+
+def symbolic_add_mod(pa: ModPoly, pb: ModPoly) -> ModPoly:
+    """ModPoly addition; corresponds to ``forward_add`` over ℤ/2³².
+
+    Same spec as :func:`symbolic_add`, reinterpreted in the quotient
+    ring. The coefficient reduction in ``ModPoly.__post_init__`` is
+    precisely the ``& MASK32`` step ``CompiledModel.forward`` applies
+    after the bilinear form.
+    """
+    return pa + pb
+
+
+def symbolic_sub_mod(pa: ModPoly, pb: ModPoly) -> ModPoly:
+    """ModPoly subtraction; corresponds to ``forward_sub`` over ℤ/2³².
+
+    Order matches :func:`symbolic_sub`: returns ``pb - pa``.
+    """
+    return pb - pa
+
+
+def symbolic_mul_mod(pa: ModPoly, pb: ModPoly) -> ModPoly:
+    """ModPoly multiplication; corresponds to ``forward_mul`` over ℤ/2³²."""
+    return pa * pb
+
+
+# Ops this module understands when interpreting the program over ℤ/2³².
+# Narrower than ``_SCOPE_OPS``: option (b) only covers the polynomial-
+# closed fragment (ADD / SUB / MUL + stack manip). Everything else —
+# comparisons (boundary gate), rationals (boundary truncation), bit-ops
+# (non-polynomial over ℤ/2³² as well; bit decomposition lives in the
+# ``BitVec`` wrapper) — raises ``BlockedOpcodeForSymbolic``. Those
+# fragments already apply the correct wrap at their own boundaries.
+_SCOPE_OPS_MOD = {
+    isa.OP_PUSH, isa.OP_POP, isa.OP_DUP, isa.OP_HALT, isa.OP_NOP,
+    isa.OP_ADD, isa.OP_SUB, isa.OP_MUL,
+    isa.OP_SWAP, isa.OP_OVER, isa.OP_ROT,
+}
+
+
+@dataclass
+class SymbolicForwardResultMod:
+    """Outcome of :func:`evaluate_program_mod` — mod-2³² sibling of
+    :class:`SymbolicForwardResult`. ``top`` is a :class:`ModPoly`.
+    """
+    top: ModPoly
+    stack: List[ModPoly]
+    n_heads: int
+    bindings: Dict[int, int]
+
+
+def evaluate_program_mod(prog) -> SymbolicForwardResultMod:
+    """Run ``prog`` through the bilinear FF interpreters over ℤ/2³².
+
+    Semantics match :func:`evaluate_program` restricted to the polynomial
+    fragment {ADD, SUB, MUL, PUSH, POP, DUP, HALT, NOP, SWAP, OVER, ROT}.
+    The one difference from the Poly-over-ℤ driver is the value type:
+    every stack entry is a :class:`ModPoly` whose coefficients are
+    reduced modulo 2³² after every arithmetic operation. Structurally
+    the output is ``ModPoly.from_poly(evaluate_program(prog).top)`` — a
+    theorem verified by :func:`test_ff_symbolic.test_modpoly_equivalence`.
+    """
+    stack: List[ModPoly] = []
+    bindings: Dict[int, int] = {}
+    next_var = 0
+    n_heads = 0
+
+    for instr in prog:
+        op = instr.op
+        if op not in _SCOPE_OPS_MOD:
+            raise BlockedOpcodeForSymbolic(
+                f"op {isa.OP_NAMES.get(op, f'?{op}')!r} is out of scope for "
+                f"the mod-2³² bilinear FF dispatch (ADD/SUB/MUL + stack "
+                f"manip only). Comparisons / rationals / bit-ops have their "
+                f"own boundary wrap in IndicatorPoly / RationalPoly / BitVec."
+            )
+        if op == isa.OP_HALT:
+            break
+        if op == isa.OP_NOP:
+            continue
+        n_heads += 1
+        if op == isa.OP_PUSH:
+            v = next_var
+            next_var += 1
+            bindings[v] = int(instr.arg)
+            stack.append(ModPoly.variable(v))
+        elif op == isa.OP_POP:
+            if not stack:
+                raise IndexError("symbolic stack underflow")
+            stack.pop()
+        elif op == isa.OP_DUP:
+            if not stack:
+                raise IndexError("dup on empty stack")
+            stack.append(stack[-1])
+        elif op == isa.OP_ADD:
+            b = stack.pop(); a = stack.pop()
+            stack.append(symbolic_add_mod(a, b))
+        elif op == isa.OP_SUB:
+            b = stack.pop(); a = stack.pop()
+            stack.append(symbolic_sub_mod(a, b))
+        elif op == isa.OP_MUL:
+            b = stack.pop(); a = stack.pop()
+            stack.append(symbolic_mul_mod(a, b))
+        elif op == isa.OP_SWAP:
+            if len(stack) < 2:
+                raise IndexError("swap needs 2 entries")
+            stack[-1], stack[-2] = stack[-2], stack[-1]
+        elif op == isa.OP_OVER:
+            if len(stack) < 2:
+                raise IndexError("over needs 2 entries")
+            stack.append(stack[-2])
+        elif op == isa.OP_ROT:
+            if len(stack) < 3:
+                raise IndexError("rot needs 3 entries")
+            a, b, c = stack[-3], stack[-2], stack[-1]
+            stack[-3], stack[-2], stack[-1] = b, c, a
+        else:  # pragma: no cover — guarded by _SCOPE_OPS_MOD above
+            raise BlockedOpcodeForSymbolic(f"unreachable: op {op}")
+
+    top = stack[-1] if stack else ModPoly.constant(0)
+    return SymbolicForwardResultMod(top=top, stack=list(stack),
+                                    n_heads=n_heads, bindings=bindings)
+
+
 def evaluate_program_forking(prog, *, input_mode: str = "symbolic") -> ForkingResult:
     """Run ``prog`` through :func:`symbolic_executor.run_forking` with the
     bilinear-FF ADD/SUB/MUL primitives (issue #68 S3).
@@ -1004,9 +1151,12 @@ __all__ = [
     "symbolic_div_s", "symbolic_rem_s",
     "symbolic_cmp", "symbolic_eqz",
     "symbolic_bit_binary", "symbolic_bit_unary", "symbolic_bit_arith",
+    "symbolic_add_mod", "symbolic_sub_mod", "symbolic_mul_mod",
     "FF_ARITHMETIC_OPS",
     "SymbolicForwardResult",
+    "SymbolicForwardResultMod",
     "evaluate_program",
+    "evaluate_program_mod",
     "evaluate_program_forking",
     "range_check",
 ]

--- a/symbolic_executor.py
+++ b/symbolic_executor.py
@@ -259,6 +259,211 @@ class Poly:
         return out
 
 
+# ─── ModPoly — polynomial over ℤ / 2³² (issue #78) ────────────────
+#
+# Option (b) of issue #78: carry i32 wrap semantics through the
+# polynomial algebra rather than only at the boundary via
+# :func:`ff_symbolic.range_check`. ``ModPoly`` mirrors :class:`Poly` but
+# reduces every coefficient modulo 2³² after every operation, matching
+# the ``& MASK32`` the compiled transformer's FF layer applies to the
+# results of ADD / SUB / MUL.
+#
+# The motivating gap: ``Poly`` arithmetic computes over ℤ, so the
+# equivalence theorem from issue #69 carries a range assumption
+# (:func:`ff_symbolic.range_check`) rather than a proof. Every catalog
+# input happens to fit well inside ``[I32_MIN, I32_MAX]`` — max is
+# ``factorial(10) = 3,628,800`` — so a bug in either direction on the
+# overflow boundary would pass silently. ``ModPoly`` closes that:
+# evaluations agree with ``NumPyExecutor`` bit-for-bit under wrap, and
+# the equivalence theorem becomes *structural over ℤ/2³²* rather than
+# *numeric on in-range inputs over ℤ*.
+#
+# Structural note: ℤ/2³² is a ring but not a field (2 divides the
+# modulus, so the ring has zero divisors). That matters for DIV_S /
+# REM_S — division is not well-defined — but issue #78 scope is only
+# ADD / SUB / MUL, which are the ring operations. Comparisons /
+# bitwise / rationals stay in their existing wrappers (``IndicatorPoly``,
+# ``BitVec``, ``RationalPoly``) whose boundary evaluators already apply
+# the appropriate wrap / truncation.
+
+_MOD32 = 1 << 32
+_I31 = 1 << 31  # signed / unsigned split
+
+
+def _reduce_u32(c) -> int:
+    """Reduce a coefficient (possibly negative / Fraction-with-denom-1) to [0, 2³²)."""
+    if isinstance(c, Fraction):
+        if c.denominator != 1:
+            raise ValueError(
+                f"ModPoly cannot carry non-integer coefficients; got {c}"
+            )
+        c = int(c.numerator)
+    return int(c) & MASK32
+
+
+@dataclass(frozen=True)
+class ModPoly:
+    """Multivariate polynomial with coefficients in ℤ / 2³².
+
+    Sibling of :class:`Poly`. Closed under ``+``, ``-``, ``*`` (the ring
+    operations); every operation reduces coefficients modulo 2³² so the
+    canonical form is unique per congruence class. Structural equality
+    (``==``) is therefore well-defined per the ring.
+
+    Lift a pure-integer :class:`Poly` with :meth:`from_poly`; the result
+    is the same polynomial under the ring homomorphism ℤ → ℤ/2³².
+    Evaluation with :meth:`eval_at` agrees bit-for-bit with i32-masked
+    integer evaluation of the lifted :class:`Poly` (the homomorphism
+    property).
+    """
+
+    terms: Mapping[Monomial, int]
+
+    @staticmethod
+    def _normalise(terms: Mapping[Monomial, Union[int, Fraction]]
+                   ) -> Dict[Monomial, int]:
+        out: Dict[Monomial, int] = {}
+        for m, c in terms.items():
+            r = _reduce_u32(c)
+            if r != 0:
+                out[m] = r
+        return out
+
+    def __post_init__(self):
+        object.__setattr__(self, "terms", self._normalise(dict(self.terms)))
+
+    # ── Constructors ──────────────────────────────────────────
+
+    @classmethod
+    def constant(cls, c: int) -> "ModPoly":
+        if _reduce_u32(c) == 0:
+            return cls({})
+        return cls({(): _reduce_u32(c)})
+
+    @classmethod
+    def variable(cls, idx: int) -> "ModPoly":
+        return cls({((int(idx), 1),): 1})
+
+    @classmethod
+    def from_poly(cls, p: "Poly") -> "ModPoly":
+        """Lift a :class:`Poly` with integer coefficients via ℤ → ℤ/2³².
+
+        Raises ``ValueError`` on rational (non-integer) coefficients —
+        those belong to the rational-extension fragment (``RationalPoly``
+        from issue #75) whose boundary truncator already handles wrap.
+        """
+        return cls({m: _reduce_u32(c) for m, c in p.terms.items()})
+
+    # ── Arithmetic ────────────────────────────────────────────
+    #
+    # The addition / subtraction / multiplication formulas are
+    # identical to ``Poly``; what changes is the post-op coefficient
+    # reduction in ``__post_init__``, which lands every result back
+    # inside [0, 2³²).
+
+    def __add__(self, other: "ModPoly") -> "ModPoly":
+        out: Dict[Monomial, int] = dict(self.terms)
+        for m, c in other.terms.items():
+            out[m] = out.get(m, 0) + c
+        return ModPoly(out)
+
+    def __sub__(self, other: "ModPoly") -> "ModPoly":
+        out: Dict[Monomial, int] = dict(self.terms)
+        for m, c in other.terms.items():
+            out[m] = out.get(m, 0) - c
+        return ModPoly(out)
+
+    def __neg__(self) -> "ModPoly":
+        return ModPoly({m: -c for m, c in self.terms.items()})
+
+    def __mul__(self, other: "ModPoly") -> "ModPoly":
+        out: Dict[Monomial, int] = {}
+        for ma, ca in self.terms.items():
+            for mb, cb in other.terms.items():
+                m = _mono_mul(ma, mb)
+                out[m] = out.get(m, 0) + ca * cb
+        return ModPoly(out)
+
+    # ── Inspection ────────────────────────────────────────────
+
+    def n_monomials(self) -> int:
+        return len(self.terms)
+
+    def variables(self) -> List[int]:
+        seen = set()
+        for m in self.terms:
+            for v, _ in m:
+                seen.add(v)
+        return sorted(seen)
+
+    def eval_at(self, bindings: Mapping[int, int]) -> int:
+        """Evaluate as an integer in ``[0, 2³²)`` — the i32-wrapped result.
+
+        Uses the ring homomorphism: evaluate over ℤ (Python's arbitrary-
+        precision ints) and reduce once at the end. Equivalent to
+        reducing after every multiply / add thanks to the homomorphism;
+        the bulk form is simpler.
+        """
+        total = 0
+        for mono, coeff in self.terms.items():
+            term = coeff
+            for v, p in mono:
+                term *= int(bindings[v]) ** p
+            total += term
+        return int(total) & MASK32
+
+    def eval_at_signed(self, bindings: Mapping[int, int]) -> int:
+        """Evaluate and reinterpret as signed i32 (``[-2³¹, 2³¹)``)."""
+        u = self.eval_at(bindings)
+        return u - _MOD32 if u >= _I31 else u
+
+    # ── Equality / display ────────────────────────────────────
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, ModPoly):
+            return NotImplemented
+        return self.terms == other.terms
+
+    def __hash__(self) -> int:
+        return hash(tuple(sorted(self.terms.items())))
+
+    def __repr__(self) -> str:
+        if not self.terms:
+            return "0 (mod 2³²)"
+
+        def _key(item):
+            m, _ = item
+            return (sum(p for _, p in m), m)
+
+        def _signed(c: int) -> int:
+            # Display coefficients near the upper boundary as negative
+            # — so ``-1 mod 2³² = 4_294_967_295`` prints as ``-1`` instead
+            # of the (correct but unreadable) u32 form. Makes catalog-
+            # sized polynomials read identically to their ``Poly`` twin.
+            return c - _MOD32 if c >= _I31 else c
+
+        pieces = []
+        for mono, coeff in sorted(self.terms.items(), key=_key):
+            ms = _mono_str(mono)
+            disp = _signed(coeff)
+            if ms == "1":
+                pieces.append(str(disp))
+                continue
+            if disp == 1:
+                pieces.append(ms)
+            elif disp == -1:
+                pieces.append(f"-{ms}")
+            else:
+                pieces.append(f"{disp}·{ms}")
+        out = pieces[0]
+        for p in pieces[1:]:
+            if p.startswith("-"):
+                out += f" - {p[1:]}"
+            else:
+                out += f" + {p}"
+        return f"{out} (mod 2³²)"
+
+
 # ─── Sign-indicator form (issue #76) ──────────────────────────────
 #
 # Comparisons (EQ, NE, LT_S, GT_S, LE_S, GE_S, EQZ) are not polynomial
@@ -1861,6 +2066,7 @@ def collapse_report(prog: List[isa.Instruction], *,
 
 __all__ = [
     "Poly",
+    "ModPoly",
     "RationalPoly",
     "SymbolicRemainder",
     "IndicatorPoly",

--- a/test_ff_symbolic.py
+++ b/test_ff_symbolic.py
@@ -40,6 +40,7 @@ from symbolic_executor import (
     BitVec,
     GuardedPoly,
     IndicatorPoly,
+    ModPoly,
     Poly,
     RationalPoly,
     REL_EQ,
@@ -1019,6 +1020,330 @@ def test_bitvec_parameter_count():
 
 # ─── Blocked-opcode handling ──────────────────────────────────────
 
+# ─── ModPoly / mod-2³² equivalence (issue #78 option (b)) ────────
+#
+# Issue #78 asks for the equivalence theorem to be "honest about i32
+# wrap" — either pin the range (#69 Option (a), already landed) or
+# carry wrap semantics in the algebra (Option (b)). These tests
+# exercise Option (b): ``ModPoly`` closes the ``& MASK32`` gap by
+# reducing coefficients modulo 2³² after every ADD/SUB/MUL, so the
+# equivalence becomes *structural over ℤ/2³²* — not just numeric on
+# in-range inputs.
+#
+# Coverage:
+#   1. Primitives on ``ModPoly`` + mod-32 symbolic primitives wrap
+#      correctly at the 32-bit boundary.
+#   2. Every pure-Poly collapsed catalog row has
+#      ``ModPoly.from_poly(run_symbolic(P).top) == evaluate_program_mod(P).top``.
+#   3. Two overflow-stressing programs where the ℤ result doesn't fit
+#      in i32 still match NumPyExecutor bit-for-bit under wrap.
+#   4. Ring-homomorphism check: the lift of the Poly-over-ℤ driver's
+#      output equals the mod-32 driver's output on every catalog row.
+#   5. Blocked opcodes outside the polynomial fragment (DIV_S, JZ,
+#      comparisons, bitwise) raise ``BlockedOpcodeForSymbolic`` from
+#      ``evaluate_program_mod`` rather than silently returning a
+#      ModPoly that doesn't carry the wrap semantics of the boundary
+#      wrappers.
+
+
+def test_modpoly_primitives():
+    """ModPoly constructors, arithmetic, wrap behaviour."""
+    # Constants wrap cleanly.
+    _check("ModPoly.constant(0) == empty", ModPoly.constant(0) == ModPoly({}))
+    _check("ModPoly.constant(2**32) == 0",
+           ModPoly.constant(1 << 32) == ModPoly.constant(0))
+    _check("ModPoly.constant(-1) == MASK32",
+           ModPoly.constant(-1) == ModPoly.constant(0xFFFFFFFF))
+
+    # Variables are the same shape as Poly's.
+    x0 = ModPoly.variable(0)
+    x1 = ModPoly.variable(1)
+    _check("variable structure",
+           x0.terms == {((0, 1),): 1})
+
+    # Addition wraps at the coefficient level.
+    big = ModPoly.constant(0xFFFFFFFF)
+    one = ModPoly.constant(1)
+    _check("MASK32 + 1 wraps to 0", (big + one) == ModPoly.constant(0))
+
+    # Subtraction produces a canonical unsigned form.
+    _check("0 - 1 == MASK32",
+           (ModPoly.constant(0) - ModPoly.constant(1))
+           == ModPoly.constant(0xFFFFFFFF))
+
+    # Negation.
+    _check("neg(1) == MASK32",
+           (-ModPoly.constant(1)) == ModPoly.constant(0xFFFFFFFF))
+
+    # Multiplication wraps. 100_000 * 100_000 = 10**10 ≡ 1_410_065_408 (mod 2³²).
+    hundred_k = ModPoly.constant(100_000)
+    _check("100k * 100k wraps",
+           (hundred_k * hundred_k) == ModPoly.constant(1_410_065_408))
+
+    # 2¹⁶ squared is 2³², which is 0 mod 2³². Structural witness of the
+    # zero-divisor behaviour ℤ/2³² exhibits.
+    sixteen_bit = ModPoly.constant(1 << 16)
+    _check("2^16 * 2^16 == 0 mod 2^32",
+           (sixteen_bit * sixteen_bit) == ModPoly.constant(0))
+
+    # eval_at matches a native & MASK32 on an out-of-range value.
+    sq = ModPoly.variable(0) * ModPoly.variable(0)
+    _check("eval_at wraps 46341^2",
+           sq.eval_at({0: 46341}) == (46341 * 46341) & 0xFFFFFFFF)
+    _check("eval_at_signed on overflow",
+           sq.eval_at_signed({0: 46341}) == -2_147_479_015)
+    _check("eval_at handles negative binding",
+           sq.eval_at({0: -1}) == 1)
+
+
+def test_symbolic_primitives_mod():
+    """ff.symbolic_{add,sub,mul}_mod = ModPoly +/−/*, order matches numeric."""
+    a = ModPoly.variable(0)
+    b = ModPoly.variable(1)
+    _check("symbolic_add_mod", ff.symbolic_add_mod(a, b) == a + b)
+    # SUB order: forward_sub returns b - a (pa = top = a; pb = SP-1 = b).
+    _check("symbolic_sub_mod order", ff.symbolic_sub_mod(a, b) == b - a)
+    _check("symbolic_mul_mod", ff.symbolic_mul_mod(a, b) == a * b)
+
+    # Composition reduces at every step — the homomorphism property.
+    # Building (x+y)² symbolically with constants near the boundary:
+    # coefficients stay within [0, 2³²) after every intermediate step.
+    k = ModPoly.constant(0xFFFF_FFFE)  # -2 (mod 2³²)
+    _check("compose: k + 2 == 0 mod 2^32",
+           (ff.symbolic_add_mod(k, ModPoly.constant(2))) == ModPoly.constant(0))
+
+
+def _collapsed_poly_entries():
+    """Catalog rows whose ``run_symbolic.top`` is a plain ``Poly``.
+
+    That's the subset where ModPoly's scope applies directly. Other
+    collapsed rows (RationalPoly / IndicatorPoly / BitVec) have their
+    own boundary wrap handled inside those wrappers' ``eval_at`` and
+    are out of scope for the mod-2³² algebra.
+    """
+    out = []
+    for entry in _default_catalog():
+        cr = classify_program(entry.prog)
+        if cr.status == STATUS_COLLAPSED and cr.poly is not None:
+            out.append(entry)
+    return out
+
+
+def test_modpoly_catalog_structural():
+    """For every pure-Poly collapsed row:
+
+    ``ModPoly.from_poly(run_symbolic(P).top) == evaluate_program_mod(P).top``.
+
+    Structural equality in ℤ/2³², not merely numerical — the canonical
+    term dict matches after mod-32 reduction. This is the honest
+    equivalence theorem option (b) asks for.
+    """
+    entries = _collapsed_poly_entries()
+    _check("mod32 catalog has rows", len(entries) > 0,
+           f"expected >0, got {len(entries)}")
+    for entry in entries:
+        sym = run_symbolic(entry.prog)
+        if not isinstance(sym.top, Poly):
+            continue
+        lifted = ModPoly.from_poly(sym.top)
+        mod_res = ff.evaluate_program_mod(entry.prog)
+        _check(
+            f"mod32.struct[{entry.name}]",
+            lifted == mod_res.top,
+            f"lifted={lifted!r} mod={mod_res.top!r}",
+        )
+        _check(
+            f"mod32.n_heads[{entry.name}]",
+            sym.n_heads == mod_res.n_heads,
+            f"sym={sym.n_heads}, mod={mod_res.n_heads}",
+        )
+
+
+def test_modpoly_homomorphism_on_catalog():
+    """Ring-homomorphism witness on every collapsed row.
+
+    ``ModPoly.from_poly(evaluate_program(P).top) == evaluate_program_mod(P).top``
+    — lifting commutes with the driver. The one-liner proof is that
+    each primitive (``symbolic_{add,sub,mul}`` and ``_mod`` variants)
+    reduces to the same coefficient-level operation, just in a
+    different ring. The test asserts it actually holds programmatically.
+    """
+    for entry in _collapsed_poly_entries():
+        poly_res = ff.evaluate_program(entry.prog)
+        if not isinstance(poly_res.top, Poly):
+            continue
+        lifted = ModPoly.from_poly(poly_res.top)
+        mod_res = ff.evaluate_program_mod(entry.prog)
+        _check(
+            f"mod32.homo[{entry.name}]",
+            lifted == mod_res.top,
+            f"lifted={lifted!r} mod={mod_res.top!r}",
+        )
+
+
+def test_modpoly_catalog_numeric():
+    """Evaluate the mod-32 top at catalog bindings — match NumPyExecutor.
+
+    Unlike ``test_equivalence_numeric`` (which asserts over ℤ and
+    requires the value to clear ``range_check``), this evaluates in
+    ℤ/2³² directly — the sides agree by construction, range_check
+    notwithstanding.
+    """
+    np_exec = NumPyExecutor()
+    for entry in _collapsed_poly_entries():
+        mod = ff.evaluate_program_mod(entry.prog)
+        mod_val = mod.top.eval_at(mod.bindings) if mod.bindings else mod.top.eval_at({})
+        np_trace = np_exec.execute(entry.prog)
+        np_top = np_trace.steps[-1].top if np_trace.steps else None
+        # NumPyExecutor stores u32-masked values; ModPoly.eval_at returns u32.
+        _check(
+            f"mod32.numeric[{entry.name}]",
+            mod_val == (int(np_top) & 0xFFFFFFFF),
+            f"mod={mod_val}, np={np_top}",
+        )
+
+
+def test_modpoly_overflow_stress():
+    """Two overflow-stressing cases where ℤ and ℤ/2³² disagree.
+
+    Issue #78 explicitly calls these out as the missing coverage under
+    Option (a): "Today's tests live inside the range where both sides
+    agree, so a bug in either direction would pass silently." Each
+    program here has an honest value > I32_MAX that only agrees with
+    the native path under i32 wrap.
+
+    Three-way check per case: run_symbolic over ℤ (out of range; fails
+    range_check), evaluate_program_mod (in ℤ/2³²), NumPyExecutor
+    (masked). ModPoly ≡ NumPy bit-for-bit; ℤ-evaluated Poly disagrees.
+    """
+    np_exec = NumPyExecutor()
+
+    # Case 1: MUL on sqrt(I32_MAX)-ish inputs. 46341² = 2_147_488_281
+    # overflows signed i32 (I32_MAX = 2_147_483_647) by 4_634. Stays in
+    # u32, so NumPyExecutor's masked u32 view matches the unmasked ℤ
+    # value here — but the *signed* reading differs, and the structure
+    # of the test is to show ModPoly is the one that agrees with
+    # NumPyExecutor under ALL i32 inputs, not just in-range ones.
+    prog1 = program(
+        ("PUSH", 46341), ("DUP",), ("MUL",), ("HALT",),
+    )
+    sym1 = run_symbolic(prog1)
+    mod1 = ff.evaluate_program_mod(prog1)
+    np1 = np_exec.execute(prog1).steps[-1].top
+    mod_val1 = mod1.top.eval_at(mod1.bindings)
+    z_val1 = sym1.top.eval_at(sym1.bindings)
+    _check(
+        "overflow[46341^2].modpoly==numpy",
+        mod_val1 == (int(np1) & 0xFFFFFFFF),
+        f"mod={mod_val1}, np={np1}",
+    )
+    _check(
+        "overflow[46341^2].z_matches_too",
+        z_val1 == 46341 * 46341,
+        f"z={z_val1}",
+    )
+    # The diagnostic: ℤ value is still equal to masked u32 here (2_147_488_281
+    # < 2³² = 4_294_967_296), so both interpretations happen to agree.
+    # range_check rejects it though.
+    try:
+        ff.range_check(z_val1, context="46341^2")
+        _fail("overflow[46341^2].range_rejects", "range_check accepted overflow")
+    except ff.RangeCheckFailure:
+        _pass("overflow[46341^2].range_rejects")
+
+    # Case 2: MUL beyond u32. 100_000 * 100_000 = 10¹⁰ > 2³² (= 4_294_967_296).
+    # ℤ-evaluated Poly = 10_000_000_000; ℤ/2³² = 1_410_065_408 = NumPy's
+    # masked top. ModPoly is the only side that agrees with NumPyExecutor.
+    prog2 = program(
+        ("PUSH", 100_000), ("PUSH", 100_000), ("MUL",), ("HALT",),
+    )
+    sym2 = run_symbolic(prog2)
+    mod2 = ff.evaluate_program_mod(prog2)
+    np2 = np_exec.execute(prog2).steps[-1].top
+    mod_val2 = mod2.top.eval_at(mod2.bindings)
+    z_val2 = sym2.top.eval_at(sym2.bindings)
+    _check(
+        "overflow[100k*100k].modpoly==numpy",
+        mod_val2 == (int(np2) & 0xFFFFFFFF),
+        f"mod={mod_val2}, np={np2}",
+    )
+    _check(
+        "overflow[100k*100k].z_disagrees",
+        z_val2 != (int(np2) & 0xFFFFFFFF) and z_val2 == 10_000_000_000,
+        f"z={z_val2}, np={np2}",
+    )
+
+    # Case 3 (bonus): 2¹⁶ squared = 2³² ≡ 0 (mod 2³²). Zero-divisor
+    # witness inside ℤ/2³²; NumPyExecutor also reports 0.
+    prog3 = program(
+        ("PUSH", 1 << 16), ("DUP",), ("MUL",), ("HALT",),
+    )
+    mod3 = ff.evaluate_program_mod(prog3)
+    np3 = np_exec.execute(prog3).steps[-1].top
+    _check(
+        "overflow[2^16 squared == 0]",
+        mod3.top.eval_at(mod3.bindings) == 0 and (int(np3) & 0xFFFFFFFF) == 0,
+        f"mod={mod3.top.eval_at(mod3.bindings)}, np={np3}",
+    )
+
+    # Case 4 (bonus): ADD that overflows. I32_MAX + 2 = -I32_MAX (signed wrap).
+    # We do it via PUSHes that themselves exceed i31; evaluate_program_mod
+    # still produces x0 + x1 symbolically (coefficients unchanged) — the
+    # wrap happens at eval_at.
+    prog4 = program(
+        ("PUSH", 0x7FFFFFFF), ("PUSH", 2), ("ADD",), ("HALT",),
+    )
+    mod4 = ff.evaluate_program_mod(prog4)
+    np4 = np_exec.execute(prog4).steps[-1].top
+    _check(
+        "overflow[I32_MAX + 2].modpoly==numpy",
+        mod4.top.eval_at(mod4.bindings) == (int(np4) & 0xFFFFFFFF),
+        f"mod={mod4.top.eval_at(mod4.bindings)}, np={np4}",
+    )
+
+
+def test_modpoly_blocked_opcodes():
+    """Ops outside the polynomial-closed fragment raise in evaluate_program_mod.
+
+    ModPoly is deliberately narrower than ``evaluate_program`` — its
+    scope is the ring (ADD/SUB/MUL + stack manip). Everything else
+    (comparisons, rationals, bit-ops) keeps its own boundary wrap and
+    must NOT silently become a ModPoly lacking those semantics.
+    """
+    # DIV_S — rational fragment has its own boundary (RationalPoly).
+    prog = program(("PUSH", 10), ("PUSH", 3), ("DIV_S",), ("HALT",))
+    try:
+        ff.evaluate_program_mod(prog)
+        _fail("mod32.blocked[DIV_S]", "expected BlockedOpcodeForSymbolic")
+    except ff.BlockedOpcodeForSymbolic:
+        _pass("mod32.blocked[DIV_S]")
+
+    # LT_S — comparison gate, not polynomial.
+    prog = program(("PUSH", 3), ("PUSH", 5), ("LT_S",), ("HALT",))
+    try:
+        ff.evaluate_program_mod(prog)
+        _fail("mod32.blocked[LT_S]", "expected BlockedOpcodeForSymbolic")
+    except ff.BlockedOpcodeForSymbolic:
+        _pass("mod32.blocked[LT_S]")
+
+    # AND — bitwise, lives in BitVec AST.
+    prog = program(("PUSH", 5), ("PUSH", 3), ("AND",), ("HALT",))
+    try:
+        ff.evaluate_program_mod(prog)
+        _fail("mod32.blocked[AND]", "expected BlockedOpcodeForSymbolic")
+    except ff.BlockedOpcodeForSymbolic:
+        _pass("mod32.blocked[AND]")
+
+    # JZ — control flow; the mod-32 driver is straight-line like its
+    # Poly-over-ℤ sibling.
+    prog = program(("PUSH", 1), ("JZ", 10), ("HALT",))
+    try:
+        ff.evaluate_program_mod(prog)
+        _fail("mod32.blocked[JZ]", "expected BlockedOpcodeForSymbolic")
+    except ff.BlockedOpcodeForSymbolic:
+        _pass("mod32.blocked[JZ]")
+
+
 def test_blocked_opcodes():
     """Ops outside the fragment raise BlockedOpcodeForSymbolic.
 
@@ -1099,6 +1424,13 @@ def main():
         test_equivalence_is_power_of_2_structural,
         test_equivalence_bitvec_numeric,
         test_bitvec_parameter_count,
+        test_modpoly_primitives,
+        test_symbolic_primitives_mod,
+        test_modpoly_catalog_structural,
+        test_modpoly_homomorphism_on_catalog,
+        test_modpoly_catalog_numeric,
+        test_modpoly_overflow_stress,
+        test_modpoly_blocked_opcodes,
         test_blocked_opcodes,
     ]
     print("=" * 60)


### PR DESCRIPTION
## Summary

Implements **option (b)** of issue #78: carry i32 wrap semantics directly in the algebra by introducing polynomials over ℤ/2³². This complements option (a) — range pinning via \`range_check()\` — which already landed in PR #73 and is retained for guard-based programs.

## What changed

- **\`symbolic_executor.py\`** — new \`ModPoly\` class: a sibling to \`Poly\` whose coefficients are reduced mod 2³² after every operation. Supports \`+\`, \`-\`, \`*\`, \`from_poly()\`, \`eval_at()\` (returns u32), \`eval_at_signed()\` (returns i32). Zero divisors are handled correctly (e.g. 2¹⁶ · 2¹⁶ = 0 in the ring).

- **\`ff_symbolic.py\`** — \`evaluate_program_mod()\`, a mod-2³² driver that mirrors \`evaluate_program\` but runs over \`ModPoly\`. Scope is intentionally narrower than the ℤ driver: only \`ADD\`/\`SUB\`/\`MUL\` and pure stack manipulation. \`DIV_S\`/cmp/bitwise remain in their existing wrapper types (\`RationalPoly\`, \`IndicatorPoly\`, \`BitVec\`) where boundary-wrap already lives.

- **\`test_ff_symbolic.py\`** — 7 new test functions:
  - \`test_modpoly_primitives\` / \`test_symbolic_primitives_mod\` — ring arithmetic smoke tests.
  - \`test_modpoly_catalog_structural\` — \`run_symbolic(prog) ≡ from_poly(evaluate_program(prog).top)\` structurally on catalog rows with polynomial tops.
  - \`test_modpoly_homomorphism_on_catalog\` — verifies the ring homomorphism ℤ → ℤ/2³² commutes with the driver.
  - \`test_modpoly_catalog_numeric\` — numeric equivalence on concrete inputs.
  - \`test_modpoly_overflow_stress\` — four overflow cases that distinguish ℤ from ℤ/2³²: 46341², 100 000 · 100 000 (>2³²), 2¹⁶ · 2¹⁶ = 0 (zero divisor), \`I32_MAX + 2\`.
  - \`test_modpoly_blocked_opcodes\` — confirms the narrower scope blocks DIV_S, cmp, bitwise, and branches under the mod driver.

- **\`dev/ff_symbolic_equivalence.md\`** — updated the "Range / i32-wrap" section to note option (b) landing, and added a new "Wrap-aware extension" section with structural/numeric statements, overflow-stress coverage table, and explicit non-goals.

## Test plan

- [x] \`python3 test_ff_symbolic.py\` → 455 PASS (up from 368)
- [x] The 10 pre-existing bit-vector argument-ordering failures are unrelated to #78 (they exist on \`main\` as well)
- [x] ModPoly homomorphism verified to commute with \`evaluate_program\` on all polynomial catalog rows
- [x] Overflow cases exhibit the expected u32/i32 values

Closes #78.