### PR TITLE
X2: guarded_to_mermaid — decision-tree viz for GuardedPoly traces

### DIFF
--- a/dev/symbolic_collapse_report.md
+++ b/dev/symbolic_collapse_report.md
@@ -52,6 +52,20 @@ number stay distinguishable. _value Σ size_ / _value max depth_
 sum and max across cases' value trees; _guard Σ size_ / _guard
 max depth_ do the same across every guard tree.
 
+**Visualising partition structure.** The flat `[(guards, value), ...]`
+table can be rendered as a decision-tree diagram via
+`symbolic_executor.guarded_to_mermaid(gp)`. Example for
+`clamp_zero(5)`:
+
+```mermaid
+flowchart TD
+    D1{"x0 != 0"}
+    L2["x0"]
+    D1 -->|True| L2
+    L3["x5"]
+    D1 -->|False| L3
+```
+
 | Program | k heads | # cases | cases | value Σ size | value max depth | guard Σ size | guard max depth | match |
 |---|---:|---:|---|---:|---:|---:|---:|:-:|
 | `select_by_sign(7)` | 5 | 2 | `{x0 != 0} → x4`<br>`{x0 == 0} → x7` | 2 | 0 | 2 | 0 | ✓ |

--- a/symbolic_executor.py
+++ b/symbolic_executor.py
@@ -2064,6 +2064,79 @@ def collapse_report(prog: List[isa.Instruction], *,
             f"monomials, top = {r.top}")
 
 
+def guarded_to_mermaid(gp: "GuardedPoly") -> str:
+    """Render a ``GuardedPoly`` case table as a Mermaid flowchart decision tree.
+
+    Returns valid Mermaid ``flowchart TD`` source. The last case is rendered
+    as an implicit ``else`` leaf — its guards are implied by the preceding
+    decisions — so a 2-case / single-guard GuardedPoly produces exactly one
+    decision diamond and two value leaves.
+
+    Multi-guard cases chain their guards with ``True`` edges; the ``False``
+    edge of each case's last guard connects to the next case.
+    """
+    def _label(g: "Guard") -> str:
+        return f"{g.poly} {_REL_SYMBOL[g.relation]} 0"
+
+    def _mq(s: str) -> str:
+        return '"' + s.replace('"', "'") + '"'
+
+    lines = ["flowchart TD"]
+    ctr = [0]
+
+    def _fresh(prefix: str) -> str:
+        ctr[0] += 1
+        return f"{prefix}{ctr[0]}"
+
+    cases = list(gp.cases)
+    n = len(cases)
+    pending: Optional[Tuple[str, str]] = None  # (from_node_id, edge_label)
+
+    for i, (guards, value) in enumerate(cases):
+        guards_list = list(guards)
+
+        if i == n - 1:
+            # Last case: render as implied else leaf (guards follow by elimination).
+            leaf = _fresh("L")
+            lines.append(f"    {leaf}[{_mq(repr(value))}]")
+            if pending:
+                src, lbl = pending
+                lines.append(f"    {src} -->|{lbl}| {leaf}")
+            break
+
+        if not guards_list:
+            # Unconditional middle case (degenerate; shouldn't appear in a valid partition).
+            leaf = _fresh("L")
+            lines.append(f"    {leaf}[{_mq(repr(value))}]")
+            if pending:
+                src, lbl = pending
+                lines.append(f"    {src} -->|{lbl}| {leaf}")
+            pending = None
+            continue
+
+        # Chain each guard in the conjunction with True edges between them.
+        prev_dec: Optional[str] = None
+        for j, g in enumerate(guards_list):
+            dec = _fresh("D")
+            lines.append(f"    {dec}{{{_mq(_label(g))}}}")
+            if j == 0 and pending:
+                src, lbl = pending
+                lines.append(f"    {src} -->|{lbl}| {dec}")
+            elif j > 0 and prev_dec is not None:
+                lines.append(f"    {prev_dec} -->|True| {dec}")
+            prev_dec = dec
+
+        # True branch of the last guard leads to this case's value leaf.
+        leaf = _fresh("L")
+        lines.append(f"    {leaf}[{_mq(repr(value))}]")
+        lines.append(f"    {prev_dec} -->|True| {leaf}")
+
+        # False branch of the last guard connects to the next case.
+        pending = (prev_dec, "False")
+
+    return "\n".join(lines)
+
+
 __all__ = [
     "Poly",
     "ModPoly",
@@ -2088,4 +2161,5 @@ __all__ = [
     "run_symbolic",
     "run_forking",
     "collapse_report",
+    "guarded_to_mermaid",
 ]

--- a/test_symbolic_executor.py
+++ b/test_symbolic_executor.py
@@ -36,6 +36,7 @@ from symbolic_executor import (
     SymbolicOpNotSupported,
     SymbolicStackUnderflow,
     collapse_report,
+    guarded_to_mermaid,
     run_forking,
     run_symbolic,
 )
@@ -593,6 +594,81 @@ def test_collapse_report_format():
     assert "9 heads" in msg
     assert "1 monomial" in msg
     assert "16·x0" in msg
+
+
+# ─── guarded_to_mermaid ───────────────────────────────────────────
+
+def _simple_gp() -> GuardedPoly:
+    """2-case single-guard GuardedPoly: {x0 == 0} → x5 | {x0 != 0} → x0."""
+    x0 = Poly.variable(0)
+    x5 = Poly.variable(5)
+    return GuardedPoly(cases=(
+        ((Guard(x0, REL_EQ),), x5),
+        ((Guard(x0, REL_NE),), x0),
+    ))
+
+
+def test_guarded_to_mermaid_flowchart_header():
+    """Output starts with the required Mermaid flowchart directive."""
+    out = guarded_to_mermaid(_simple_gp())
+    assert out.startswith("flowchart TD"), repr(out[:60])
+
+
+def test_guarded_to_mermaid_covers_every_case_exactly_once():
+    """Each case's value_poly appears as a Mermaid leaf label exactly once."""
+    gp = _simple_gp()
+    out = guarded_to_mermaid(gp)
+    for _guards, value in gp.cases:
+        # Use the full leaf-node syntax ["value"] to avoid false positives
+        # from guard labels that may contain the same substring.
+        leaf_pat = f'["{repr(value)}"]'
+        count = out.count(leaf_pat)
+        assert count == 1, (
+            f"{leaf_pat!r} appears {count} times (expected 1) in:\n{out}"
+        )
+
+
+def test_guarded_to_mermaid_two_case_has_one_decision_node():
+    """A 2-case single-guard GuardedPoly produces exactly 1 decision diamond."""
+    import re
+    out = guarded_to_mermaid(_simple_gp())
+    # Decision nodes look like D1{...} in the output
+    decision_lines = [ln for ln in out.splitlines() if re.search(r'\bD\d+\{', ln)]
+    assert len(decision_lines) == 1, (
+        f"Expected 1 decision node, got {len(decision_lines)}:\n{out}"
+    )
+
+
+def test_guarded_to_mermaid_true_and_false_edges_present():
+    """The output contains both True and False edges for a binary split."""
+    out = guarded_to_mermaid(_simple_gp())
+    assert "|True|" in out, f"Missing True edge:\n{out}"
+    assert "|False|" in out, f"Missing False edge:\n{out}"
+
+
+def test_guarded_to_mermaid_three_case_has_two_decision_nodes():
+    """A 3-case GuardedPoly produces exactly 2 decision nodes."""
+    import re
+    x0 = Poly.variable(0)
+    x1 = Poly.variable(1)
+    x2 = Poly.variable(2)
+    # Construct a 3-case partition: x0<0, x0>0, else (x0==0)
+    gp = GuardedPoly(cases=(
+        ((Guard(x0, REL_LT),), x1),
+        ((Guard(x0, REL_GT),), x2),
+        ((Guard(x0, REL_EQ),), Poly.constant(0)),
+    ))
+    out = guarded_to_mermaid(gp)
+    decision_lines = [ln for ln in out.splitlines() if re.search(r'\bD\d+\{', ln)]
+    assert len(decision_lines) == 2, (
+        f"Expected 2 decision nodes, got {len(decision_lines)}:\n{out}"
+    )
+    # All 3 case values appear exactly once as leaf labels.
+    for _guards, value in gp.cases:
+        leaf_pat = f'["{repr(value)}"]'
+        assert out.count(leaf_pat) == 1, (
+            f"{leaf_pat!r} should appear exactly once as a leaf:\n{out}"
+        )
 
 
 # ─── Runner ───────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #80.

## Summary

- Adds `symbolic_executor.guarded_to_mermaid(gp: GuardedPoly) -> str` that renders any GuardedPoly case table as a Mermaid `flowchart TD` decision tree
- The last case is treated as the implied `else` leaf (guards implied by elimination), so a 2-case / single-guard partition produces exactly **one decision diamond** and two value leaves — the cleanest possible tree
- Multi-guard conjunctions chain their guards with `True` edges; the `False` edge of each case's last guard connects to the next case
- Adds five tests in `test_symbolic_executor.py` covering: flowchart header, full case coverage (all leaves present exactly once), decision-node count for 2-case and 3-case inputs, and True/False edge presence
- Updates `dev/symbolic_collapse_report.md` with a visualisation hint and inline Mermaid example for `clamp_zero(5)`

## Example output

For `clamp_zero(5)` (`{x0 != 0} → x0 | {x0 == 0} → x5`):

```mermaid
flowchart TD
    D1{"x0 != 0"}
    L2["x0"]
    D1 -->|True| L2
    L3["x5"]
    D1 -->|False| L3
```

## Test plan

- [x] All 42 tests in `test_symbolic_executor.py` pass
- [x] `guarded_to_mermaid` exported via `__all__`
- [x] Integration hint added to `dev/symbolic_collapse_report.md`

https://claude.ai/code/session_019yH4VJTMC39xHmKPQnNxsz