### PR TITLE
feat: poly_to_program() compiler + unit tests (issue #94)

### DIFF
--- a/dev/poly_compiler_context.md
+++ b/dev/poly_compiler_context.md
@@ -1,0 +1,287 @@
+# poly_compiler_context.md
+
+Pre-digested reference for poly_to_program implementation.
+DO NOT read symbolic_executor.py (50K+ tokens). This file has everything needed.
+
+## Opcode constants (from isa.py)
+
+```python
+OP_PUSH = 1
+OP_POP  = 2
+OP_ADD  = 3
+OP_DUP  = 4
+OP_HALT = 5
+OP_SUB = 6
+OP_JZ  = 7
+OP_JNZ = 8
+OP_NOP = 9
+OP_SWAP = 10
+OP_OVER = 11
+OP_ROT  = 12
+OP_MUL   = 13
+OP_DIV_S = 14
+OP_DIV_U = 15
+OP_REM_S = 16
+OP_REM_U = 17
+OP_EQZ   = 18
+OP_EQ    = 19
+OP_NE    = 20
+OP_LT_S  = 21
+OP_LT_U  = 22
+OP_GT_S  = 23
+OP_GT_U  = 24
+OP_LE_S  = 25
+OP_LE_U  = 26
+OP_GE_S  = 27
+OP_GE_U  = 28
+OP_AND   = 29
+OP_OR    = 30
+OP_XOR   = 31
+OP_SHL   = 32
+OP_SHR_S = 33
+OP_SHR_U = 34
+OP_ROTL  = 35
+OP_ROTR  = 36
+OP_CLZ    = 37
+OP_CTZ    = 38
+OP_POPCNT = 39
+OP_ABS    = 40
+OP_NEG    = 41
+OP_SELECT = 42
+OP_LOCAL_GET = 43
+OP_LOCAL_SET = 44
+OP_LOCAL_TEE = 45
+OP_I32_LOAD    = 46
+OP_I32_STORE   = 47
+OP_I32_LOAD8_U = 48
+OP_I32_LOAD8_S = 49
+OP_I32_LOAD16_U = 50
+OP_I32_LOAD16_S = 51
+OP_I32_STORE8  = 52
+OP_I32_STORE16 = 53
+OP_CALL   = 54
+OP_RETURN = 55
+OP_TRAP  = 99
+```
+
+## Instruction class (from isa.py)
+
+```python
+class Instruction:
+    op: int
+    arg: int = 0
+
+    def __repr__(self):
+        name = OP_NAMES.get(self.op, f"?{self.op}")
+        if self.op in (OP_PUSH, OP_JZ, OP_JNZ,
+                        OP_LOCAL_GET, OP_LOCAL_SET, OP_LOCAL_TEE,
+                        OP_CALL):
+            return f"{name} {self.arg}"
+        return name
+```
+
+## Poly class (from symbolic_executor.py)
+
+```python
+class Poly:
+    """Multivariate polynomial with rational coefficients.
+
+    ``terms`` maps a monomial (canonical-form tuple) to its coefficient,
+    which is ``int`` when the coefficient is integral and
+    :class:`fractions.Fraction` when the denominator is >1. Zero-
+    coefficient entries are never stored.
+    """
+
+    terms: Mapping[Monomial, Union[int, Fraction]]
+
+    @staticmethod
+    def _normalise(terms: Mapping[Monomial, Union[int, Fraction]]
+                   ) -> Dict[Monomial, Union[int, Fraction]]:
+        return {m: _norm_coeff(c) for m, c in terms.items() if c != 0}
+
+    def __post_init__(self):
+        # Freeze a normalised copy. Doing it this way so callers can pass
+        # any mapping and still get the value-equality guarantee.
+        object.__setattr__(self, "terms", self._normalise(dict(self.terms)))
+
+    # ── Constructors ──────────────────────────────────────────
+
+    @classmethod
+    def constant(cls, c: Union[int, Fraction]) -> "Poly":
+        if c == 0:
+            return cls({})
+        return cls({(): _norm_coeff(c)})
+
+    @classmethod
+    def variable(cls, idx: int) -> "Poly":
+        return cls({((int(idx), 1),): 1})
+
+    # ── Arithmetic ────────────────────────────────────────────
+
+    def __add__(self, other: "Poly") -> "Poly":
+        out: Dict[Monomial, int] = dict(self.terms)
+        for m, c in other.terms.items():
+            out[m] = out.get(m, 0) + c
+        return Poly(out)
+
+    def __sub__(self, other: "Poly") -> "Poly":
+        out: Dict[Monomial, int] = dict(self.terms)
+        for m, c in other.terms.items():
+            out[m] = out.get(m, 0) - c
+        return Poly(out)
+
+    def __neg__(self) -> "Poly":
+        return Poly({m: -c for m, c in self.terms.items()})
+
+    def __mul__(self, other: "Poly") -> "Poly":
+        out: Dict[Monomial, int] = {}
+        for ma, ca in self.terms.items():
+            for mb, cb in other.terms.items():
+                m = _mono_mul(ma, mb)
+                out[m] = out.get(m, 0) + ca * cb
+        return Poly(out)
+
+    # ── Inspection ────────────────────────────────────────────
+
+    def n_monomials(self) -> int:
+        return len(self.terms)
+
+    def variables(self) -> List[int]:
+        """Variable indices referenced by any monomial, sorted."""
+        seen = set()
+        for m in self.terms:
+            for v, _ in m:
+                seen.add(v)
+        return sorted(seen)
+
+    def eval_at(self, bindings: Mapping[int, int]) -> Union[int, Fraction]:
+        """Substitute ``bindings[i]`` for each ``x_i`` and reduce.
+
+        Returns ``int`` when the result is integral (the common case for
+        ADD/SUB/MUL Polys), otherwise returns :class:`fractions.Fraction`
+        (after a DIV_S introduces a rational coefficient). Missing
+        variables raise ``KeyError`` — symbolic executors that emit a
+        variable per PUSH should pass one binding per PUSH.
+        """
+        total: Union[int, Fraction] = 0
+        for mono, coeff in self.terms.items():
+            term: Union[int, Fraction] = coeff
+            for v, p in mono:
+                term *= bindings[v] ** p
+            total += term
+        return _norm_coeff(total)
+
+    # ── Equality / display ────────────────────────────────────
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Poly):
+            return NotImplemented
+        return self.terms == other.terms
+
+    def __hash__(self) -> int:
+        return hash(tuple(sorted(self.terms.items())))
+
+    def __repr__(self) -> str:  # deterministic for tests
+        if not self.terms:
+            return "0"
+        # sort by (total degree, monomial) for readable output
+        def _key(item):
+            m, _ = item
+            return (sum(p for _, p in m), m)
+
+        pieces = []
+        for mono, coeff in sorted(self.terms.items(), key=_key):
+            ms = _mono_str(mono)
+            if ms == "1":
+                pieces.append(str(coeff))
+                continue
+            if coeff == 1:
+                pieces.append(ms)
+            elif coeff == -1:
+                pieces.append(f"-{ms}")
+            else:
+                pieces.append(f"{coeff}·{ms}")
+        # join with explicit signs
+        out = pieces[0]
+        for p in pieces[1:]:
+            if p.startswith("-"):
+                out += f" - {p[1:]}"
+            else:
+                out += f" + {p}"
+        return out
+```
+
+## _POLY_OPS (from symbolic_executor.py)
+
+```python
+_POLY_OPS = {
+    isa.OP_PUSH, isa.OP_POP, isa.OP_DUP, isa.OP_HALT,
+    isa.OP_ADD, isa.OP_SUB, isa.OP_MUL,
+    isa.OP_DIV_S, isa.OP_REM_S,
+    isa.OP_SWAP, isa.OP_OVER, isa.OP_ROT, isa.OP_NOP,
+} | _CMP_OPS | _BITVEC_OPCODES
+```
+
+## SymbolicResult (from symbolic_executor.py)
+
+```python
+class SymbolicResult:
+    """Outcome of running a program symbolically.
+
+    ``top`` is the top-of-stack value after HALT (or at the end of the
+    trace if HALT is absent). For the ADD/SUB/MUL fragment it's a
+    :class:`Poly`; for the DIV_S / REM_S rows added in issue #75 it can
+    also be :class:`RationalPoly` or :class:`SymbolicRemainder`. ``stack``
+    is the full final stack (bottom at index 0). ``n_heads`` is the
+    number of instructions executed — the "k heads" the issue talks
+    about. ``bindings`` maps the allocated variable indices back to the
+    original PUSH constants.
+    """
+
+    top: RationalStackValue
+    stack: List[RationalStackValue]
+    n_heads: int
+    bindings: Dict[int, int]
+
+    def collapse_ratio(self) -> float:
+        """k_heads ÷ n_monomials in the top expression, after simplification.
+
+        Matches the issue's "9 heads → 1 monomial" style report. Returns
+        ``inf`` when the top collapses to zero (no monomials) — flagged
+        by callers who want a cleaner representation. For rational
+        outputs (DIV_S / REM_S) the denominator counts as an additional
+        monomial bundle; we sum the two sides' monomial counts to keep
+        the "one number" shape of the ratio.
+        """
+        if isinstance(self.top, Poly):
+            n = self.top.n_monomials()
+        elif isinstance(self.top, (RationalPoly, SymbolicRemainder)):
+            n = self.top.num.n_monomials() + self.top.denom.n_monomials()
+        else:
+            return float("inf")
+        if n == 0:
+            return float("inf")
+        return self.n_heads / n
+```
+
+## run_symbolic semantics (key behaviors)
+
+```
+PUSH arg  → allocate fresh variable x_i (next_var++), push Poly.variable(i)
+            Two PUSHes with same concrete value produce DISTINCT variables.
+POP       → pop top
+DUP       → copy top (same Poly reference, NOT a new variable)
+SWAP      → swap top two
+OVER      → copy second-from-top to top
+ROT       → [a, b, c] → [b, c, a]  (depth-2 element to top)
+ADD       → pop b, pop a, push a + b  (Poly addition)
+SUB       → pop b, pop a, push a - b  (Poly subtraction)
+MUL       → pop b, pop a, push a * b  (Poly multiplication)
+HALT      → stop execution, top of stack is result
+```
+
+## Round-trip invariant
+
+```python
+run_symbolic(poly_to_program(p)).top == p
+```

--- a/poly_compiler.py
+++ b/poly_compiler.py
@@ -1,0 +1,290 @@
+"""Compiler from Poly -> branchless LAC program (issue #94).
+
+Round-trip invariant::
+
+    run_symbolic(poly_to_program(p)).top == p
+
+for any ``Poly`` with integer coefficients, zero constant term, and
+contiguous variables {0, 1, ..., n-1}.
+
+Emitted programs use only the ``_POLY_OPS`` subset:
+PUSH, POP, DUP, SWAP, OVER, ROT, ADD, SUB, MUL, HALT.
+
+**Constant-term restriction:** the output ring of branchless programs
+cannot represent bare integer constants.  ``poly_to_program`` validates
+the input and raises ``ValueError`` on non-zero constant terms.
+
+**Negative coefficients** consume extra variable indices: the negation
+trick PUSHes a dummy, DUPs it, SUBs to manufacture 0, then SUBs the
+value to negate.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import List, Optional, Union
+
+import isa
+from isa import Instruction
+from symbolic_executor import Poly
+
+
+# -- Public API -------------------------------------------------------
+
+
+def poly_to_program(poly: Poly) -> List[Instruction]:
+    """Compile a Poly into a branchless LAC program.
+
+    Parameters
+    ----------
+    poly : Poly
+        Must have integer coefficients and zero constant term.
+        Variables must be contiguous from 0.
+
+    Returns
+    -------
+    List[Instruction]
+        A branchless program whose symbolic execution yields ``poly``.
+
+    Raises
+    ------
+    ValueError
+        Non-zero constant term, fractional coefficient, or
+        non-contiguous variable indices.
+    """
+    # -- Validate -----------------------------------------------------
+    for mono, coeff in poly.terms.items():
+        if isinstance(coeff, Fraction):
+            raise ValueError(
+                f"poly_to_program: fractional coefficient {coeff} "
+                f"not compilable to ADD/SUB/MUL fragment"
+            )
+    if () in poly.terms:
+        raise ValueError(
+            "poly_to_program: non-zero constant term is not representable "
+            "in the branchless compiled-transformer ring"
+        )
+
+    # Zero polynomial -> PUSH, DUP, SUB -> x0 - x0 = 0
+    if not poly.terms:
+        return [
+            Instruction(isa.OP_PUSH, 0),
+            Instruction(isa.OP_DUP),
+            Instruction(isa.OP_SUB),
+            Instruction(isa.OP_HALT),
+        ]
+
+    vars_used = poly.variables()
+    n_vars = max(vars_used) + 1 if vars_used else 0
+    if vars_used != list(range(n_vars)):
+        raise ValueError(
+            f"poly_to_program: variables must be contiguous from 0; "
+            f"got {vars_used}"
+        )
+
+    ctx = _CompilerContext()
+
+    # -- Phase 1: PUSH base variables ---------------------------------
+    for _ in range(n_vars):
+        ctx.emit(isa.OP_PUSH, 0)
+
+    # -- Phase 2: compile monomials -----------------------------------
+    monomials = list(poly.terms.items())
+
+    for mono_idx, (mono, coeff) in enumerate(monomials):
+        coeff = int(coeff)
+        abs_coeff = abs(coeff)
+
+        # Build the monomial's variable-product on top of stack.
+        parts = 0
+        for var_idx, power in mono:
+            ctx.copy_var(var_idx)
+            for _ in range(power - 1):
+                ctx.emit(isa.OP_DUP)
+            for _ in range(power - 1):
+                ctx.emit(isa.OP_MUL)
+            parts += 1
+
+        # MUL partial products together
+        for _ in range(parts - 1):
+            ctx.emit(isa.OP_MUL)
+
+        # Scale by |coeff|
+        if abs_coeff > 1:
+            for _ in range(abs_coeff - 1):
+                ctx.emit(isa.OP_DUP)
+            for _ in range(abs_coeff - 1):
+                ctx.emit(isa.OP_ADD)
+
+        # Negate if needed
+        if coeff < 0:
+            ctx.emit_negate()
+
+        # Accumulate with prior monomials
+        if mono_idx == 0:
+            ctx.accum_vsidx = len(ctx.vstack) - 1
+        else:
+            # The accumulator may have been displaced by ROT during
+            # copy_var.  Bring it adjacent to the monomial result
+            # (currently on top) before ADD.
+            mono_top = len(ctx.vstack) - 1
+            accum_depth = mono_top - ctx.accum_vsidx
+
+            if accum_depth == 1:
+                ctx.emit(isa.OP_ADD)
+            elif accum_depth == 2:
+                # ROT brings accum to top; ADD pops accum + mono_result.
+                ctx.emit(isa.OP_ROT)
+                ctx.emit(isa.OP_ADD)
+            elif accum_depth == 0:
+                raise RuntimeError(
+                    "accumulator collided with monomial result"
+                )
+            else:
+                raise NotImplementedError(
+                    f"accumulator at depth {accum_depth}; "
+                    f"need deeper stack access (file a follow-up)"
+                )
+            ctx.accum_vsidx = len(ctx.vstack) - 1
+
+    # -- Phase 3: discard base variables ------------------------------
+    # Stack has base vars below the result.  Repeated SWAP+POP peels
+    # them off regardless of their ordering (ROT may have permuted them).
+    n_base = len(ctx.vstack) - 1  # everything except the top (result)
+    for _ in range(n_base):
+        ctx.emit(isa.OP_SWAP)
+        ctx.emit(isa.OP_POP)
+
+    ctx.emit(isa.OP_HALT)
+    return ctx.instrs
+
+
+# -- Compiler internals -----------------------------------------------
+
+
+class _CompilerContext:
+    """Virtual-stack tracker and instruction emitter.
+
+    Tracks:
+    - ``vstack``: tag per stack slot (``'v0'``, ``'v1'``, ... for base
+      variables; ``'expr'`` for computed values).
+    - ``accum_vsidx``: position of the monomial accumulator in vstack,
+      updated through every emitted instruction so it stays valid even
+      after ROT/SWAP reorderings.
+    """
+
+    def __init__(self):
+        self.instrs: List[Instruction] = []
+        self.vstack: List[str] = []
+        self.next_var: int = 0
+        self.accum_vsidx: Optional[int] = None
+
+    def emit(self, op: int, arg: int = 0) -> None:
+        """Append one instruction and update bookkeeping."""
+        self.instrs.append(Instruction(op, arg))
+        self._track_accum(op)
+        self._mirror(op)
+
+    # -- High-level helpers -------------------------------------------
+
+    def copy_var(self, var_idx: int) -> None:
+        """Copy base variable ``var_idx`` to top of stack."""
+        tag = f"v{var_idx}"
+        pos = self._find_tag(tag)
+        depth = len(self.vstack) - 1 - pos
+
+        if depth == 0:
+            self.emit(isa.OP_DUP)
+        elif depth == 1:
+            self.emit(isa.OP_OVER)
+        elif depth == 2:
+            self.emit(isa.OP_ROT)
+            self.emit(isa.OP_DUP)
+        else:
+            for _ in range(depth - 2):
+                self.emit(isa.OP_ROT)
+                self.emit(isa.OP_SWAP)
+            self.emit(isa.OP_ROT)
+            self.emit(isa.OP_DUP)
+
+    def emit_negate(self) -> None:
+        """Negate top of stack: PUSH dummy, DUP, SUB (->0), SWAP, SUB."""
+        self.emit(isa.OP_PUSH, 0)
+        self.emit(isa.OP_DUP)
+        self.emit(isa.OP_SUB)
+        self.emit(isa.OP_SWAP)
+        self.emit(isa.OP_SUB)
+
+    # -- Accumulator position tracking --------------------------------
+
+    def _track_accum(self, op: int) -> None:
+        """Update ``accum_vsidx`` to reflect the effect of ``op``.
+
+        Called BEFORE ``_mirror`` (so ``len(self.vstack)`` is the
+        pre-instruction stack size).
+        """
+        p = self.accum_vsidx
+        if p is None:
+            return
+        n = len(self.vstack)
+        if op == isa.OP_PUSH or op == isa.OP_DUP or op == isa.OP_OVER:
+            # Stack grows by 1; items below unchanged.
+            pass
+        elif op == isa.OP_POP:
+            if p == n - 1:
+                self.accum_vsidx = None  # consumed!
+            # else: unchanged
+        elif op == isa.OP_SWAP:
+            if p == n - 1:
+                self.accum_vsidx = n - 2
+            elif p == n - 2:
+                self.accum_vsidx = n - 1
+        elif op == isa.OP_ROT:
+            if n >= 3:
+                if p == n - 3:
+                    self.accum_vsidx = n - 1
+                elif p == n - 2:
+                    self.accum_vsidx = n - 3
+                elif p == n - 1:
+                    self.accum_vsidx = n - 2
+        elif op in (isa.OP_ADD, isa.OP_SUB, isa.OP_MUL):
+            # Pops top 2, pushes 1.  Items at positions < n-2 unchanged.
+            if p >= n - 2:
+                # Consumed by binary op -- this is the accumulate ADD
+                # itself; caller will reset accum_vsidx afterwards.
+                self.accum_vsidx = None
+            # else: unchanged
+
+    # -- Virtual stack bookkeeping ------------------------------------
+
+    def _find_tag(self, tag: str) -> int:
+        """Find bottom-most position of ``tag`` in the virtual stack."""
+        for i, t in enumerate(self.vstack):
+            if t == tag:
+                return i
+        raise KeyError(f"variable tag {tag!r} not found in virtual stack")
+
+    def _mirror(self, op: int) -> None:
+        """Mirror one instruction's effect on the virtual stack."""
+        vs = self.vstack
+        if op == isa.OP_PUSH:
+            vs.append(f"v{self.next_var}")
+            self.next_var += 1
+        elif op == isa.OP_POP:
+            vs.pop()
+        elif op == isa.OP_DUP:
+            vs.append(vs[-1])
+        elif op == isa.OP_SWAP:
+            vs[-1], vs[-2] = vs[-2], vs[-1]
+        elif op == isa.OP_OVER:
+            vs.append(vs[-2])
+        elif op == isa.OP_ROT:
+            a, b, c = vs[-3], vs[-2], vs[-1]
+            vs[-3], vs[-2], vs[-1] = b, c, a
+        elif op in (isa.OP_ADD, isa.OP_SUB, isa.OP_MUL):
+            vs.pop()
+            vs[-1] = "expr"
+        elif op == isa.OP_HALT:
+            pass
+        elif op == isa.OP_NOP:
+            pass

--- a/test_poly_compiler.py
+++ b/test_poly_compiler.py
@@ -1,0 +1,197 @@
+"""Unit tests for poly_to_program (issue #94).
+
+Each test verifies the round-trip invariant:
+    run_symbolic(poly_to_program(p)).top == p
+"""
+
+import pytest
+import sys, os
+sys.path.insert(0, os.path.dirname(__file__))
+
+from symbolic_executor import Poly, run_symbolic
+from poly_compiler import poly_to_program
+
+
+def _round_trip(p: Poly) -> Poly:
+    """Compile, execute symbolically, return top."""
+    prog = poly_to_program(p)
+    result = run_symbolic(prog)
+    return result.top
+
+
+# -- Issue #94 hand-picked test cases ---------------------------------
+
+
+class TestIssue94Cases:
+    """Cases listed explicitly in the issue body."""
+
+    def test_x0(self):
+        """x0 -> PUSH, HALT"""
+        p = Poly.variable(0)
+        assert _round_trip(p) == p
+
+    def test_x0_plus_x1(self):
+        """x0 + x1 -> PUSH, PUSH, ADD, HALT"""
+        p = Poly.variable(0) + Poly.variable(1)
+        assert _round_trip(p) == p
+
+    def test_3x0(self):
+        """3*x0 -> PUSH, DUP, DUP, ADD, ADD, HALT (or equivalent)"""
+        p = Poly({((0, 1),): 3})
+        assert _round_trip(p) == p
+
+    def test_x0_times_x1(self):
+        """x0*x1 -> PUSH, PUSH, MUL, HALT"""
+        p = Poly.variable(0) * Poly.variable(1)
+        assert _round_trip(p) == p
+
+    def test_x0_squared(self):
+        """x0^2 -> PUSH, DUP, MUL, HALT"""
+        p = Poly.variable(0) * Poly.variable(0)
+        assert _round_trip(p) == p
+
+    def test_x0_minus_x1(self):
+        """x0 - x1 -> PUSH, PUSH, SUB, HALT"""
+        p = Poly.variable(0) - Poly.variable(1)
+        assert _round_trip(p) == p
+
+    def test_neg_x0(self):
+        """Negative coefficient: -x0"""
+        p = -Poly.variable(0)
+        assert _round_trip(p) == p
+
+    def test_neg_2x0(self):
+        """Negative coefficient: -2*x0"""
+        p = Poly({((0, 1),): -2})
+        assert _round_trip(p) == p
+
+    def test_x0x1_plus_x0(self):
+        """Multi-monomial: x0*x1 + x0"""
+        p = Poly.variable(0) * Poly.variable(1) + Poly.variable(0)
+        assert _round_trip(p) == p
+
+    def test_2x0_plus_3x1(self):
+        """Multi-monomial: 2*x0 + 3*x1"""
+        x0, x1 = Poly.variable(0), Poly.variable(1)
+        p = Poly({((0, 1),): 2, ((1, 1),): 3})
+        assert _round_trip(p) == p
+
+    def test_constant_raises(self):
+        """Validation: Poly.constant(5) raises"""
+        with pytest.raises(ValueError, match="constant term"):
+            poly_to_program(Poly.constant(5))
+
+    def test_zero_poly(self):
+        """Zero polynomial: Poly.constant(0) -> trivial program"""
+        p = Poly.constant(0)
+        result = _round_trip(p)
+        assert result == p
+
+
+# -- Additional coverage ---------------------------------------------
+
+
+class TestNegativeCoefficients:
+
+    def test_neg_3x0(self):
+        p = Poly({((0, 1),): -3})
+        assert _round_trip(p) == p
+
+    def test_neg_x0_plus_x1(self):
+        """-x0 + x1"""
+        p = -Poly.variable(0) + Poly.variable(1)
+        assert _round_trip(p) == p
+
+    def test_x0_minus_2x1(self):
+        """x0 - 2*x1"""
+        p = Poly({((0, 1),): 1, ((1, 1),): -2})
+        assert _round_trip(p) == p
+
+
+class TestHigherPowers:
+
+    def test_x0_cubed(self):
+        x0 = Poly.variable(0)
+        p = x0 * x0 * x0
+        assert _round_trip(p) == p
+
+    def test_x0_fourth(self):
+        x0 = Poly.variable(0)
+        p = x0 * x0 * x0 * x0
+        assert _round_trip(p) == p
+
+    def test_x0_squared_x1(self):
+        """x0^2 * x1"""
+        p = Poly({((0, 2), (1, 1)): 1})
+        assert _round_trip(p) == p
+
+
+class TestMultiMonomial:
+
+    def test_x0x1_plus_x0_plus_x1(self):
+        """x0*x1 + x0 + x1"""
+        x0, x1 = Poly.variable(0), Poly.variable(1)
+        p = x0 * x1 + x0 + x1
+        assert _round_trip(p) == p
+
+    def test_x0_squared_plus_x0(self):
+        """x0^2 + x0"""
+        x0 = Poly.variable(0)
+        p = x0 * x0 + x0
+        assert _round_trip(p) == p
+
+    def test_x0_squared_minus_x0(self):
+        """x0^2 - x0"""
+        x0 = Poly.variable(0)
+        p = x0 * x0 - x0
+        assert _round_trip(p) == p
+
+    def test_three_monomials(self):
+        """2*x0^2 + 3*x0 + x1  (no bare constant; all terms have vars)"""
+        p = Poly({((0, 2),): 2, ((0, 1),): 3, ((1, 1),): 1})
+        assert _round_trip(p) == p
+
+
+class TestEvalConsistency:
+    """Verify that eval_at on the round-tripped poly matches."""
+
+    def test_eval_x0_squared_plus_x1(self):
+        p = Poly({((0, 2),): 1, ((1, 1),): 1})
+        prog = poly_to_program(p)
+        result = run_symbolic(prog)
+        # The round-tripped poly should eval identically
+        # We need to use the result's bindings for any extra vars
+        # from negation dummies, but since coeff > 0 here there are none.
+        assert result.top.eval_at({0: 7, 1: 3}) == p.eval_at({0: 7, 1: 3})
+
+    def test_eval_neg_coeff(self):
+        p = Poly({((0, 1),): -2, ((1, 1),): 3})
+        prog = poly_to_program(p)
+        result = run_symbolic(prog)
+        # result.top has extra variables from negation dummies.
+        # Bind them to 0 (since PUSH 0 is what we emit).
+        bindings = {0: 5, 1: 4}
+        # Add dummy var bindings from result
+        for v in result.top.variables():
+            if v not in bindings:
+                bindings[v] = 0
+        assert result.top.eval_at(bindings) == p.eval_at({0: 5, 1: 4})
+
+
+class TestValidation:
+
+    def test_fractional_coeff_raises(self):
+        from fractions import Fraction
+        p = Poly({((0, 1),): Fraction(1, 2)})
+        with pytest.raises(ValueError, match="fractional"):
+            poly_to_program(p)
+
+    def test_noncontiguous_vars_raises(self):
+        """Variables {0, 2} (gap at 1) should raise."""
+        p = Poly({((0, 1),): 1, ((2, 1),): 1})
+        with pytest.raises(ValueError, match="contiguous"):
+            poly_to_program(p)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Implements `poly_to_program(poly: Poly) -> List[Instruction]` that compiles a `Poly` into a branchless LAC program using only the `_POLY_OPS` subset.

## Implementation (`poly_compiler.py`)

**Algorithm:**
1. PUSH once per variable (allocates `x0, x1, ...`)
2. For each monomial: copy vars from base via DUP/OVER/ROT, raise to power, scale by coefficient
3. ADD monomial results into accumulator
4. SWAP+POP to discard base variables; HALT

**Key challenges solved:**
- **Stack access**: DUP (depth 0), OVER (depth 1), ROT+DUP (depth 2), repeated ROT+SWAP for depth ≥ 3
- **Accumulator displacement**: ROT+DUP permutes the base, displacing the monomial accumulator. Solved with explicit `accum_vsidx` tracking through every emitted instruction
- **Negative coefficients**: PUSH dummy + DUP + SUB (manufacture 0) + SWAP + SUB. Consumes one extra variable index per negation
- **Coefficient scaling**: DUP (k-1) times + ADD (k-1) times for coefficient k

## Tests (`test_poly_compiler.py`) — 26 tests, all green

All issue #94 hand-picked cases plus additional coverage:
- Single variable, sums, products, powers (x0², x0³, x0⁴)
- Negative coefficients (-x0, -2x0, -3x0, -x0 + x1)
- Multi-monomial (x0·x1 + x0, 2x0 + 3x1, x0·x1 + x0 + x1, x0² + x0)
- Cross-variable products with powers (x0²·x1)
- Validation: constant term raises, fractional coeff raises, non-contiguous vars raises
- Zero polynomial round-trip
- eval_at consistency checks

## Round-trip invariant

Every test verifies: `run_symbolic(poly_to_program(p)).top == p`

Closes #94