### PR TITLE
Fix #100: route variable access through LOCAL_GET/SET

### DIFF
--- a/poly_compiler.py
+++ b/poly_compiler.py
@@ -7,8 +7,16 @@ Round-trip invariant::
 for any ``Poly`` with integer coefficients, zero constant term, and
 contiguous variables {0, 1, ..., n-1}.
 
-Emitted programs use only the ``_POLY_OPS`` subset:
-PUSH, POP, DUP, SWAP, OVER, ROT, ADD, SUB, MUL, HALT.
+Emitted programs use the ``_POLY_OPS`` subset:
+PUSH, POP, DUP, SWAP, OVER, ROT, ADD, SUB, MUL, LOCAL_GET, LOCAL_SET, HALT.
+
+**Strategy (issue #100 fix):**
+Each source variable ``x_i`` is PUSHed once and then immediately stashed
+into local slot ``i`` via ``LOCAL_SET``. Every subsequent use fetches a
+fresh copy via ``LOCAL_GET i``. This bypasses the top-3 reach limit of
+ROT/SWAP/OVER that the prior ``copy_var`` dance ran into: locals are
+O(1)-addressable regardless of stack depth, so there is no longer a
+``depth > 2`` broken branch to fix.
 
 **Constant-term restriction:** the output ring of branchless programs
 cannot represent bare integer constants.  ``poly_to_program`` validates
@@ -16,13 +24,14 @@ the input and raises ``ValueError`` on non-zero constant terms.
 
 **Negative coefficients** consume extra variable indices: the negation
 trick PUSHes a dummy, DUPs it, SUBs to manufacture 0, then SUBs the
-value to negate.
+value to negate. The dummy and its duplicate cancel algebraically so
+the output polynomial never mentions them.
 """
 
 from __future__ import annotations
 
 from fractions import Fraction
-from typing import List, Optional, Union
+from typing import List
 
 import isa
 from isa import Instruction
@@ -84,9 +93,13 @@ def poly_to_program(poly: Poly) -> List[Instruction]:
 
     ctx = _CompilerContext()
 
-    # -- Phase 1: PUSH base variables ---------------------------------
-    for _ in range(n_vars):
+    # -- Phase 1: bind each source variable to a local slot -----------
+    # The symbolic executor assigns PUSH #k -> v_k, so PUSHing in source
+    # order preserves the variable-index convention required by
+    # ``result.top == p`` round-trip equality.
+    for i in range(n_vars):
         ctx.emit(isa.OP_PUSH, 0)
+        ctx.emit(isa.OP_LOCAL_SET, i)
 
     # -- Phase 2: compile monomials -----------------------------------
     monomials = list(poly.terms.items())
@@ -96,12 +109,15 @@ def poly_to_program(poly: Poly) -> List[Instruction]:
         abs_coeff = abs(coeff)
 
         # Build the monomial's variable-product on top of stack.
+        # Each (var, power) contributes one v^power factor; we then
+        # MUL across factors to combine them.
         parts = 0
         for var_idx, power in mono:
-            ctx.copy_var(var_idx)
+            # LOCAL_GET the variable and raise to `power` via repeated
+            # self-multiplication. v^1 is just one LOCAL_GET.
+            ctx.emit(isa.OP_LOCAL_GET, var_idx)
             for _ in range(power - 1):
-                ctx.emit(isa.OP_DUP)
-            for _ in range(power - 1):
+                ctx.emit(isa.OP_LOCAL_GET, var_idx)
                 ctx.emit(isa.OP_MUL)
             parts += 1
 
@@ -109,7 +125,7 @@ def poly_to_program(poly: Poly) -> List[Instruction]:
         for _ in range(parts - 1):
             ctx.emit(isa.OP_MUL)
 
-        # Scale by |coeff|
+        # Scale by |coeff| via repeated addition: |c|*x = x + x + ... + x
         if abs_coeff > 1:
             for _ in range(abs_coeff - 1):
                 ctx.emit(isa.OP_DUP)
@@ -120,40 +136,10 @@ def poly_to_program(poly: Poly) -> List[Instruction]:
         if coeff < 0:
             ctx.emit_negate()
 
-        # Accumulate with prior monomials
-        if mono_idx == 0:
-            ctx.accum_vsidx = len(ctx.vstack) - 1
-        else:
-            # The accumulator may have been displaced by ROT during
-            # copy_var.  Bring it adjacent to the monomial result
-            # (currently on top) before ADD.
-            mono_top = len(ctx.vstack) - 1
-            accum_depth = mono_top - ctx.accum_vsidx
-
-            if accum_depth == 1:
-                ctx.emit(isa.OP_ADD)
-            elif accum_depth == 2:
-                # ROT brings accum to top; ADD pops accum + mono_result.
-                ctx.emit(isa.OP_ROT)
-                ctx.emit(isa.OP_ADD)
-            elif accum_depth == 0:
-                raise RuntimeError(
-                    "accumulator collided with monomial result"
-                )
-            else:
-                raise NotImplementedError(
-                    f"accumulator at depth {accum_depth}; "
-                    f"need deeper stack access (file a follow-up)"
-                )
-            ctx.accum_vsidx = len(ctx.vstack) - 1
-
-    # -- Phase 3: discard base variables ------------------------------
-    # Stack has base vars below the result.  Repeated SWAP+POP peels
-    # them off regardless of their ordering (ROT may have permuted them).
-    n_base = len(ctx.vstack) - 1  # everything except the top (result)
-    for _ in range(n_base):
-        ctx.emit(isa.OP_SWAP)
-        ctx.emit(isa.OP_POP)
+        # Accumulate with prior monomials. The first monomial becomes
+        # the accumulator; subsequent ones ADD onto it from the top.
+        if mono_idx > 0:
+            ctx.emit(isa.OP_ADD)
 
     ctx.emit(isa.OP_HALT)
     return ctx.instrs
@@ -163,128 +149,29 @@ def poly_to_program(poly: Poly) -> List[Instruction]:
 
 
 class _CompilerContext:
-    """Virtual-stack tracker and instruction emitter.
+    """Minimal instruction emitter.
 
-    Tracks:
-    - ``vstack``: tag per stack slot (``'v0'``, ``'v1'``, ... for base
-      variables; ``'expr'`` for computed values).
-    - ``accum_vsidx``: position of the monomial accumulator in vstack,
-      updated through every emitted instruction so it stays valid even
-      after ROT/SWAP reorderings.
+    The ``LOCAL_GET``/``LOCAL_SET``-based strategy means we no longer
+    need the virtual-stack tag tracker, accumulator-position bookkeeping,
+    or depth-aware ``copy_var`` that the pre-#100 compiler relied on.
     """
 
     def __init__(self):
         self.instrs: List[Instruction] = []
-        self.vstack: List[str] = []
-        self.next_var: int = 0
-        self.accum_vsidx: Optional[int] = None
 
     def emit(self, op: int, arg: int = 0) -> None:
-        """Append one instruction and update bookkeeping."""
+        """Append one instruction."""
         self.instrs.append(Instruction(op, arg))
-        self._track_accum(op)
-        self._mirror(op)
-
-    # -- High-level helpers -------------------------------------------
-
-    def copy_var(self, var_idx: int) -> None:
-        """Copy base variable ``var_idx`` to top of stack."""
-        tag = f"v{var_idx}"
-        pos = self._find_tag(tag)
-        depth = len(self.vstack) - 1 - pos
-
-        if depth == 0:
-            self.emit(isa.OP_DUP)
-        elif depth == 1:
-            self.emit(isa.OP_OVER)
-        elif depth == 2:
-            self.emit(isa.OP_ROT)
-            self.emit(isa.OP_DUP)
-        else:
-            for _ in range(depth - 2):
-                self.emit(isa.OP_ROT)
-                self.emit(isa.OP_SWAP)
-            self.emit(isa.OP_ROT)
-            self.emit(isa.OP_DUP)
 
     def emit_negate(self) -> None:
-        """Negate top of stack: PUSH dummy, DUP, SUB (->0), SWAP, SUB."""
+        """Negate top of stack: PUSH dummy, DUP, SUB (->0), SWAP, SUB.
+
+        The dummy (a fresh symbolic variable in the polynomial ring)
+        immediately cancels itself via ``dummy - dummy = 0``, so it
+        leaves no trace in the final polynomial.
+        """
         self.emit(isa.OP_PUSH, 0)
         self.emit(isa.OP_DUP)
         self.emit(isa.OP_SUB)
         self.emit(isa.OP_SWAP)
         self.emit(isa.OP_SUB)
-
-    # -- Accumulator position tracking --------------------------------
-
-    def _track_accum(self, op: int) -> None:
-        """Update ``accum_vsidx`` to reflect the effect of ``op``.
-
-        Called BEFORE ``_mirror`` (so ``len(self.vstack)`` is the
-        pre-instruction stack size).
-        """
-        p = self.accum_vsidx
-        if p is None:
-            return
-        n = len(self.vstack)
-        if op == isa.OP_PUSH or op == isa.OP_DUP or op == isa.OP_OVER:
-            # Stack grows by 1; items below unchanged.
-            pass
-        elif op == isa.OP_POP:
-            if p == n - 1:
-                self.accum_vsidx = None  # consumed!
-            # else: unchanged
-        elif op == isa.OP_SWAP:
-            if p == n - 1:
-                self.accum_vsidx = n - 2
-            elif p == n - 2:
-                self.accum_vsidx = n - 1
-        elif op == isa.OP_ROT:
-            if n >= 3:
-                if p == n - 3:
-                    self.accum_vsidx = n - 1
-                elif p == n - 2:
-                    self.accum_vsidx = n - 3
-                elif p == n - 1:
-                    self.accum_vsidx = n - 2
-        elif op in (isa.OP_ADD, isa.OP_SUB, isa.OP_MUL):
-            # Pops top 2, pushes 1.  Items at positions < n-2 unchanged.
-            if p >= n - 2:
-                # Consumed by binary op -- this is the accumulate ADD
-                # itself; caller will reset accum_vsidx afterwards.
-                self.accum_vsidx = None
-            # else: unchanged
-
-    # -- Virtual stack bookkeeping ------------------------------------
-
-    def _find_tag(self, tag: str) -> int:
-        """Find bottom-most position of ``tag`` in the virtual stack."""
-        for i, t in enumerate(self.vstack):
-            if t == tag:
-                return i
-        raise KeyError(f"variable tag {tag!r} not found in virtual stack")
-
-    def _mirror(self, op: int) -> None:
-        """Mirror one instruction's effect on the virtual stack."""
-        vs = self.vstack
-        if op == isa.OP_PUSH:
-            vs.append(f"v{self.next_var}")
-            self.next_var += 1
-        elif op == isa.OP_POP:
-            vs.pop()
-        elif op == isa.OP_DUP:
-            vs.append(vs[-1])
-        elif op == isa.OP_SWAP:
-            vs[-1], vs[-2] = vs[-2], vs[-1]
-        elif op == isa.OP_OVER:
-            vs.append(vs[-2])
-        elif op == isa.OP_ROT:
-            a, b, c = vs[-3], vs[-2], vs[-1]
-            vs[-3], vs[-2], vs[-1] = b, c, a
-        elif op in (isa.OP_ADD, isa.OP_SUB, isa.OP_MUL):
-            vs.pop()
-            vs[-1] = "expr"
-        elif op == isa.OP_HALT:
-            pass
-        elif op == isa.OP_NOP:
-            pass

--- a/symbolic_executor.py
+++ b/symbolic_executor.py
@@ -1189,6 +1189,11 @@ _POLY_OPS = {
     isa.OP_ADD, isa.OP_SUB, isa.OP_MUL,
     isa.OP_DIV_S, isa.OP_REM_S,
     isa.OP_SWAP, isa.OP_OVER, isa.OP_ROT, isa.OP_NOP,
+    # Local-variable slots are polynomial-closed: a slot just stores and
+    # retrieves whatever stack value was written to it. Adding them here
+    # unlocks compilation strategies that would otherwise be blocked by
+    # the top-3 reach limit of ROT/SWAP (see issue #100).
+    isa.OP_LOCAL_GET, isa.OP_LOCAL_SET, isa.OP_LOCAL_TEE,
 } | _CMP_OPS | _BITVEC_OPCODES
 # Branch ops the forking executor additionally handles.
 _BRANCH_OPS = {isa.OP_JZ, isa.OP_JNZ}
@@ -1265,6 +1270,7 @@ def run_symbolic(prog: List[isa.Instruction]) -> SymbolicResult:
     programs with JZ/JNZ.
     """
     stack: List[RationalStackValue] = []
+    locals_: Dict[int, RationalStackValue] = {}
     bindings: Dict[int, int] = {}
     next_var = 0
     n_heads = 0
@@ -1410,6 +1416,20 @@ def run_symbolic(prog: List[isa.Instruction]) -> SymbolicResult:
             # [a, b, c] -> [b, c, a] (matches test_algorithm semantics)
             a, b, c = stack[-3], stack[-2], stack[-1]
             stack[-3], stack[-2], stack[-1] = b, c, a
+        elif op == isa.OP_LOCAL_GET:
+            if arg not in locals_:
+                raise SymbolicStackUnderflow(
+                    f"LOCAL_GET of uninitialized slot {arg}"
+                )
+            stack.append(locals_[arg])
+        elif op == isa.OP_LOCAL_SET:
+            if not stack:
+                raise SymbolicStackUnderflow("LOCAL_SET on empty stack")
+            locals_[arg] = _pop()
+        elif op == isa.OP_LOCAL_TEE:
+            if not stack:
+                raise SymbolicStackUnderflow("LOCAL_TEE on empty stack")
+            locals_[arg] = stack[-1]
         elif op in _BIT_BIN_OPS:
             # Binary bit op: ``a = SP-1``, ``b = top``. BitVec wraps each
             # operand verbatim (no simplification) — see module docstring.


### PR DESCRIPTION
Fixes #100. Unblocks #95.

## Problem

The prior `copy_var(var_idx)` implementation tried to bubble a deep
base-variable slot to the top of the stack using a ROT+SWAP loop:

```python
else:  # depth > 2 — BROKEN
    for _ in range(depth - 2):
        self.emit(isa.OP_ROT)
        self.emit(isa.OP_SWAP)
    self.emit(isa.OP_ROT)
    self.emit(isa.OP_DUP)
```

The issue (#100) noted this branch was broken and suggested a "longer
sequence that provably moves the target to the top and leaves the rest
in some predictable (possibly permuted) order." But the loop is worse
than buggy — it's architecturally unsalvageable.

**Why it cannot be fixed in place:** ROT rotates the top-3 positions
(`[a,b,c] → [b,c,a]`) and SWAP swaps the top 2. These two ops
together generate the symmetric group S₃ on positions {n-3, n-2, n-1}
only. Everything at position ≤ n-4 is strictly fixed under any
composition. No sequence of ROT/SWAP/OVER touches a slot at depth > 2
non-destructively. The _POLY_OPS allowlist (PUSH, POP, DUP, ADD, SUB,
MUL, DIV_S, REM_S, SWAP, OVER, ROT, + CMP + BITVEC) contains no
reach-extending primitive.

## Fix

Use the ISA's already-defined `OP_LOCAL_GET` / `OP_LOCAL_SET` /
`OP_LOCAL_TEE` opcodes. The numeric `executor.py` and `ff_symbolic.py`
already implement them; they were just gated out of the polynomial
symbolic executor's `_POLY_OPS` set. Locals are polynomial-closed by
construction: a slot stores whatever `Poly` the stack top was when
`LOCAL_SET` ran, and `LOCAL_GET` returns it verbatim.

Compilation becomes trivial:

1. For each source variable `x_i`: `PUSH 0; LOCAL_SET i`.
2. For each monomial: `LOCAL_GET` each factor (with inline power
   expansion via repeated `LOCAL_GET`+`MUL`), `MUL` across factors,
   scale by `|coeff|` via DUP/ADD, negate if needed, `ADD` to
   accumulator.
3. `HALT`.

No more `copy_var`, virtual-stack tag tracking, `_track_accum`,
`_find_tag`, or Phase-3 SWAP+POP cleanup. `_CompilerContext` shrinks to
a plain emitter plus `emit_negate`.

## Changes

- **`symbolic_executor.py`** (+15 / -1)
  - Add `OP_LOCAL_GET`, `OP_LOCAL_SET`, `OP_LOCAL_TEE` to `_POLY_OPS`.
  - Initialize a `locals_: Dict[int, RationalStackValue]` in
    `run_symbolic`.
  - Three handlers in the op-dispatch, each ~3 lines.

- **`poly_compiler.py`** (rewrite, 176 lines, down from 291)
  - Phase 1 becomes `PUSH; LOCAL_SET` per variable.
  - Phase 2 uses `LOCAL_GET` for every variable reference.
  - Phase 3 (SWAP+POP cleanup) removed — locals don't occupy the
    stack at HALT.
  - `_CompilerContext` reduced to `instrs`/`emit`/`emit_negate`.

## Validation

Ran locally against a fresh clone of `main` with these two files
swapped in:

- `test_poly_compiler.py` (main, 30 tests): **30/30 PASS**
- `test_symbolic_executor.py` (38 tests): **38/38 PASS** — no
  regressions from the `_POLY_OPS` expansion.
- `test_ff_symbolic.py` (42 tests): **42/42 PASS**
- `test_closed_form.py` (11 tests): **11/11 PASS**
- Issue #100 repro snippet (`n_vars` ∈ {2,3,4,5,6} linear sums):
  **all 5 PASS** (previously 4/5 FAIL).
- **With PR #101's test file dropped in** (`TestRoundTripProperty`
  + `TestEdgeCases` + `TestGeneratorReproducibility`,
  N_RANDOM=100): **237/237 PASS**, including
  `test_many_variables_all_linear` (`x0+x1+x2+x3`) and the numeric
  cross-check across 5 random inputs per seed.

(`test_consolidated.py` has a pre-existing collection error from a
missing `phase14_extended_isa` module, unrelated to this change.)

## Acceptance criteria from #100

- [x] `poly_to_program` round-trips for all 100 seeds in
      `TestRoundTripProperty`
- [x] `TestEdgeCases` passes in full (incl.
      `test_many_variables_all_linear`)
- [x] Numeric cross-check passes for the same seeds
