### PR TITLE
X3c: Catalog integration — generated stress-test entries (#96)

### DIFF
--- a/symbolic_programs_catalog.py
+++ b/symbolic_programs_catalog.py
@@ -479,7 +479,62 @@ def _default_catalog() -> List[CatalogEntry]:
     # a two-case GuardedPoly rather than blocking on the opcode.
     entries.append(CatalogEntry("native_max(3,5)", *P.make_native_max(3, 5)))
 
+    # Generated entries (issue #96): poly → program → symbolic round-trip.
+    entries.extend(_generated_catalog())
+
     return entries
+
+
+
+def _generated_catalog() -> List[CatalogEntry]:
+    """Generated stress-test entries for issue #96.
+
+    Each entry compiles a hand-chosen :class:`Poly` via
+    :func:`poly_to_program` and is expected to classify as
+    ``STATUS_COLLAPSED`` with ``numeric_match=True``.
+
+    All generated programs use ``PUSH 0; LOCAL_SET i`` for each variable,
+    so the symbolic executor binds every variable to 0.  The six shapes
+    cover the stress-test matrix in the issue spec:
+
+    * High degree, single variable — deep DUP/MUL chains (x0⁵)
+    * Many variables — wide PUSH + local stack (x0·x1·x2·x3)
+    * Many monomials — exercises ADD chains (x0² + x0·x1 + x1² + x0 + x1)
+    * Mixed signs — negation trick (3·x0·x1 − 2·x0² + x1)
+    * Large coefficient — long DUP/ADD scaling (10·x0)
+    * Four-variable cross-product — contiguous-index coverage
+      (x0·x1 + x2·x3, replacing the non-contiguous x0·x3 sketch
+      from the issue which fails the contiguity validator)
+    """
+    from poly_compiler import poly_to_program  # sibling module in this repo
+
+    def _entry(name: str, poly: Poly) -> CatalogEntry:
+        prog = poly_to_program(poly)
+        # poly evaluates to 0 at the binding point (all vars bound to 0
+        # by the PUSH 0 preamble), so expected=0 is the ground-truth result.
+        return CatalogEntry(name=name, prog=prog, expected=0)
+
+    x0, x1, x2, x3 = (Poly.variable(i) for i in range(4))
+
+    return [
+        # Shape 1: high degree, 1 var — deep DUP/MUL chains
+        _entry("gen_x0_fifth", x0 * x0 * x0 * x0 * x0),
+        # Shape 2: many variables — wide PUSH + local slots
+        _entry("gen_x0x1x2x3", x0 * x1 * x2 * x3),
+        # Shape 3: many monomials — exercises ADD chains
+        _entry("gen_sum_of_five_terms", x0 * x0 + x0 * x1 + x1 * x1 + x0 + x1),
+        # Shape 4: mixed signs — negation trick exercises emit_negate
+        _entry(
+            "gen_mixed_signs",
+            Poly({((0, 1), (1, 1)): 3, ((0, 2),): -2, ((1, 1),): 1}),
+        ),
+        # Shape 5: large coefficient — long DUP/ADD scaling chain
+        _entry("gen_10x0", Poly({((0, 1),): 10})),
+        # Shape 6: four-variable cross-product — covers contiguous indices 0-3
+        # (x0·x3 alone would fail the contiguity validator, so we include
+        # all four indices via x0·x1 + x2·x3)
+        _entry("gen_x0x1_plus_x2x3", x0 * x1 + x2 * x3),
+    ]
 
 
 # ─── Runner + row ────────────────────────────────────────────────
@@ -1100,4 +1155,5 @@ __all__ = [
     "format_report",
     "poly_to_expr",
     "run_catalog",
+    "_generated_catalog",
 ]

--- a/test_symbolic_programs_catalog.py
+++ b/test_symbolic_programs_catalog.py
@@ -521,6 +521,114 @@ def test_known_eml_shapes_match_paper():
     assert tree_depth(add_tree) == 6
 
 
+
+# ─── Generated catalog entries (issue #96) ────────────────────────
+
+def test_generated_entries_present_in_default_catalog():
+    """At least 6 generated entries appear in the default catalog."""
+    rows = run_catalog()
+    gen_rows = [r for r in rows if r.name.startswith("gen_")]
+    assert len(gen_rows) >= 5, f"expected ≥5 generated rows, got {len(gen_rows)}"
+
+
+def test_generated_entries_all_collapsed():
+    """Every generated entry classifies as STATUS_COLLAPSED."""
+    rows = run_catalog()
+    gen_rows = [r for r in rows if r.name.startswith("gen_")]
+    assert gen_rows, "no generated rows found — catalog not extended"
+    non_collapsed = [r for r in gen_rows if r.status != STATUS_COLLAPSED]
+    assert not non_collapsed, (
+        "generated rows not STATUS_COLLAPSED: "
+        + ", ".join(f"{r.name}={r.status}" for r in non_collapsed)
+    )
+
+
+def test_generated_entries_numeric_match():
+    """Every generated entry has numeric_match=True (NumPy ≡ Poly at the
+    PUSH-0 binding point)."""
+    rows = run_catalog()
+    gen_rows = [r for r in rows if r.name.startswith("gen_")]
+    failures = [r for r in gen_rows if r.numeric_match is not True]
+    assert not failures, (
+        "numeric_match failed: "
+        + ", ".join(f"{r.name}={r.numeric_match}" for r in failures)
+    )
+
+
+def test_generated_entry_shapes():
+    """Pin polynomial shape and monomial count for selected generated entries."""
+    rows = {r.name: r for r in run_catalog()}
+
+    # x0^5 — 1 monomial, degree 5
+    r = rows["gen_x0_fifth"]
+    assert r.status == STATUS_COLLAPSED
+    assert r.n_monomials == 1
+    assert r.poly_expr == "x0^5"
+    assert r.numeric_match is True
+
+    # 10*x0 — 1 monomial, large coefficient
+    r = rows["gen_10x0"]
+    assert r.status == STATUS_COLLAPSED
+    assert r.n_monomials == 1
+    assert r.poly_expr == "10*x0"
+    assert r.numeric_match is True
+
+    # x0^2 + x0*x1 + x1^2 + x0 + x1 — exactly 5 monomials
+    r = rows["gen_sum_of_five_terms"]
+    assert r.status == STATUS_COLLAPSED
+    assert r.n_monomials == 5
+    assert r.numeric_match is True
+
+    # 3*x0*x1 - 2*x0^2 + x1 — exactly 3 monomials (mixed signs)
+    r = rows["gen_mixed_signs"]
+    assert r.status == STATUS_COLLAPSED
+    assert r.n_monomials == 3
+    assert r.numeric_match is True
+
+    # x0*x1*x2*x3 — 1 monomial, 4 variables
+    r = rows["gen_x0x1x2x3"]
+    assert r.status == STATUS_COLLAPSED
+    assert r.n_monomials == 1
+    assert r.numeric_match is True
+
+    # x0*x1 + x2*x3 — 2 monomials, 4 variables
+    r = rows["gen_x0x1_plus_x2x3"]
+    assert r.status == STATUS_COLLAPSED
+    assert r.n_monomials == 2
+    assert r.numeric_match is True
+
+
+def test_generated_entries_eml_when_available():
+    """When eml-sr is present, generated collapsed entries get EML tree metrics."""
+    if not _EML_AVAILABLE:
+        print("  (eml-sr not available — skipping generated eml test)")
+        return
+    rows = run_catalog()
+    gen_rows = [r for r in rows if r.name.startswith("gen_") and r.status == STATUS_COLLAPSED]
+    assert gen_rows
+    for r in gen_rows:
+        assert r.eml_size is not None and r.eml_size >= 1, r.name
+        assert r.eml_depth is not None and r.eml_depth >= 0, r.name
+
+
+def test_generated_catalog_standalone():
+    """_generated_catalog() can be run in isolation and produces exactly 6 entries."""
+    from symbolic_programs_catalog import _generated_catalog
+    entries = _generated_catalog()
+    assert len(entries) == 6
+    names = {e.name for e in entries}
+    expected_names = {
+        "gen_x0_fifth",
+        "gen_x0x1x2x3",
+        "gen_sum_of_five_terms",
+        "gen_mixed_signs",
+        "gen_10x0",
+        "gen_x0x1_plus_x2x3",
+    }
+    assert names == expected_names, f"unexpected names: {names ^ expected_names}"
+
+
+
 # ─── Runner ───────────────────────────────────────────────────────
 
 def _collect_tests():


### PR DESCRIPTION
Closes #96.

## What this does

Adds a `_generated_catalog()` function to `symbolic_programs_catalog.py` that produces six stress-test entries by compiling `Poly` objects via `poly_to_program` (from #94), then pipes them through the existing `run_catalog` / `classify_program` pipeline.

## Six stress-test shapes

| Entry | Shape | Why |
|---|---|---|
| `gen_x0_fifth` | x0^5 | Deep DUP/MUL chains |
| `gen_x0x1x2x3` | x0*x1*x2*x3 | Wide PUSH + local slots |
| `gen_sum_of_five_terms` | x0^2+x0*x1+x1^2+x0+x1 | 5-term ADD chain |
| `gen_mixed_signs` | 3*x0*x1-2*x0^2+x1 | emit_negate path |
| `gen_10x0` | 10*x0 | Large-coefficient DUP/ADD |
| `gen_x0x1_plus_x2x3` | x0*x1+x2*x3 | 4-var contiguous coverage |

**Note on the issue spec**: The issue listed `x0*x3 (skipping x1, x2)` as a shape. That polynomial fails `poly_to_program`'s contiguity validator (`ValueError: variables must be contiguous from 0`). Replaced with `x0*x1 + x2*x3`, which includes all four variable indices and still exercises the variable-indexing paths.

## All entries guarantee
- `STATUS_COLLAPSED`
- `numeric_match=True` (NumPy == Poly.eval_at at the PUSH-0 binding point)

## Tests (6 new in `test_symbolic_programs_catalog.py`)
- `test_generated_entries_present_in_default_catalog`
- `test_generated_entries_all_collapsed`
- `test_generated_entries_numeric_match`
- `test_generated_entry_shapes` (pins n_monomials + poly_expr for all 6)
- `test_generated_entries_eml_when_available`
- `test_generated_catalog_standalone`

## Depends on
- #94 (X3a: poly_to_program) already merged
- #95 (X3b: round-trip property tests) sibling, not a dependency