### PR TITLE
Fix #105: ff_symbolic bilinear-FF dispatch LOCAL_GET/SET/TEE

### DIFF
--- a/ff_symbolic.py
+++ b/ff_symbolic.py
@@ -790,6 +790,15 @@ _SCOPE_OPS = {
     isa.OP_AND, isa.OP_OR, isa.OP_XOR,
     isa.OP_SHL, isa.OP_SHR_S, isa.OP_SHR_U,
     isa.OP_CLZ, isa.OP_CTZ, isa.OP_POPCNT,
+    # Issue #105: LOCAL slots are transparent to the FF dispatch — a slot
+    # just stores and retrieves whatever stack value was written to it
+    # (Poly / BitVec / RationalPoly / IndicatorPoly / SymbolicRemainder),
+    # invoking no FF weight matrix. The equivalence claim from #69
+    # extends unchanged: each LOCAL_* step routes a single symbolic
+    # value through the locals table, so every arithmetic composition
+    # still bottoms out at the same M_ADD / M_SUB / B_MUL (etc.) call
+    # site as it would under pure stack manipulation.
+    isa.OP_LOCAL_GET, isa.OP_LOCAL_SET, isa.OP_LOCAL_TEE,
 }
 
 
@@ -824,6 +833,7 @@ def evaluate_program(prog) -> SymbolicForwardResult:
     form carried by :class:`RationalPoly` / :class:`SymbolicRemainder`).
     """
     stack: List[RationalStackValue] = []
+    locals_: Dict[int, RationalStackValue] = {}
     bindings: Dict[int, int] = {}
     next_var = 0
     n_heads = 0
@@ -892,8 +902,15 @@ def evaluate_program(prog) -> SymbolicForwardResult:
                 ai = _require_int_ast(a, "SUB"); bi = _require_int_ast(b, "SUB")
                 stack.append(symbolic_bit_arith(bi, ai, isa.OP_SUB))
             else:
-                stack.append(symbolic_sub(_require_poly(a, "SUB"),
-                                          _require_poly(b, "SUB")))
+                # ``symbolic_sub`` takes ``(pa=top, pb=SP-1)`` and returns
+                # ``pb - pa = SP-1 - top`` (WASM SUB). Mirrors the forking
+                # wrapper ``FF_ARITHMETIC_OPS.sub = λa,b: symbolic_sub(b, a)``
+                # and matches ``DIV_S`` / ``REM_S`` / ``symbolic_cmp``
+                # below. Issue #105 exposed this via ``gen_mixed_signs``,
+                # whose ``emit_negate`` sequence produces a negative
+                # coefficient only when the subtrahend-order is correct.
+                stack.append(symbolic_sub(_require_poly(b, "SUB"),
+                                          _require_poly(a, "SUB")))
         elif op == isa.OP_MUL:
             b = _pop(); a = _pop()
             if isinstance(a, BitVec) or isinstance(b, BitVec):
@@ -957,6 +974,28 @@ def evaluate_program(prog) -> SymbolicForwardResult:
                 raise IndexError("rot needs 3 entries")
             a, b, c = stack[-3], stack[-2], stack[-1]
             stack[-3], stack[-2], stack[-1] = b, c, a
+        elif op == isa.OP_LOCAL_GET:
+            # FF invariant: the slot holds the identical symbolic value
+            # that was written to it — no FF weight matrix is applied on
+            # read. The Poly / BitVec / RationalPoly / IndicatorPoly
+            # identity is preserved by reference, so downstream ADD / SUB
+            # / MUL / … dispatch is unchanged from the pure-stack path.
+            slot = int(instr.arg)
+            if slot not in locals_:
+                raise IndexError(f"LOCAL_GET of uninitialized slot {slot}")
+            stack.append(locals_[slot])
+        elif op == isa.OP_LOCAL_SET:
+            # Store pop-top into the slot. No algebra over the value —
+            # the FF dispatch never inspects slot contents; it only
+            # routes the write on SET and the read on GET.
+            slot = int(instr.arg)
+            locals_[slot] = _pop()
+        elif op == isa.OP_LOCAL_TEE:
+            # Peek-and-store: slot mirrors current top without popping.
+            slot = int(instr.arg)
+            if not stack:
+                raise IndexError("LOCAL_TEE on empty stack")
+            locals_[slot] = stack[-1]
         else:  # pragma: no cover — guarded by _SCOPE_OPS above
             raise BlockedOpcodeForSymbolic(f"unreachable: op {op}")
 
@@ -1024,6 +1063,12 @@ _SCOPE_OPS_MOD = {
     isa.OP_PUSH, isa.OP_POP, isa.OP_DUP, isa.OP_HALT, isa.OP_NOP,
     isa.OP_ADD, isa.OP_SUB, isa.OP_MUL,
     isa.OP_SWAP, isa.OP_OVER, isa.OP_ROT,
+    # Issue #105: LOCAL slots are polynomial-closed — a slot stores and
+    # retrieves whatever ModPoly stack value was written. They invoke
+    # no bilinear form, so the mod-2³² homomorphism (``ModPoly.from_poly
+    # ∘ evaluate_program == evaluate_program_mod`` on the collapsed-Poly
+    # catalog) extends unchanged once both drivers carry a locals table.
+    isa.OP_LOCAL_GET, isa.OP_LOCAL_SET, isa.OP_LOCAL_TEE,
 }
 
 
@@ -1050,6 +1095,7 @@ def evaluate_program_mod(prog) -> SymbolicForwardResultMod:
     theorem verified by :func:`test_ff_symbolic.test_modpoly_equivalence`.
     """
     stack: List[ModPoly] = []
+    locals_: Dict[int, ModPoly] = {}
     bindings: Dict[int, int] = {}
     next_var = 0
     n_heads = 0
@@ -1086,7 +1132,11 @@ def evaluate_program_mod(prog) -> SymbolicForwardResultMod:
             stack.append(symbolic_add_mod(a, b))
         elif op == isa.OP_SUB:
             b = stack.pop(); a = stack.pop()
-            stack.append(symbolic_sub_mod(a, b))
+            # ``symbolic_sub_mod`` takes ``(pa=top, pb=SP-1)`` and returns
+            # ``pb - pa = SP-1 - top``, matching WASM SUB and the
+            # ``FF_ARITHMETIC_OPS.sub`` wrapper. Same ordering fix as the
+            # Poly driver above (issue #105).
+            stack.append(symbolic_sub_mod(b, a))
         elif op == isa.OP_MUL:
             b = stack.pop(); a = stack.pop()
             stack.append(symbolic_mul_mod(a, b))
@@ -1103,6 +1153,30 @@ def evaluate_program_mod(prog) -> SymbolicForwardResultMod:
                 raise IndexError("rot needs 3 entries")
             a, b, c = stack[-3], stack[-2], stack[-1]
             stack[-3], stack[-2], stack[-1] = b, c, a
+        elif op == isa.OP_LOCAL_GET:
+            # Mod-2³² slot read: return the stored ModPoly unchanged.
+            # No bilinear form is invoked, so mod-32 reduction is a
+            # no-op on the GET edge — the coefficients were already
+            # reduced when the value was produced by the arithmetic
+            # primitive that wrote it.
+            slot = int(instr.arg)
+            if slot not in locals_:
+                raise IndexError(f"LOCAL_GET of uninitialized slot {slot}")
+            stack.append(locals_[slot])
+        elif op == isa.OP_LOCAL_SET:
+            # Mod-2³² slot write: pop-top into the slot. The ModPoly's
+            # invariant (coefficients in [0, 2³²)) is preserved by
+            # reference; SET applies no algebra.
+            slot = int(instr.arg)
+            if not stack:
+                raise IndexError("LOCAL_SET on empty stack")
+            locals_[slot] = stack.pop()
+        elif op == isa.OP_LOCAL_TEE:
+            # Mod-2³² peek-and-store: slot mirrors current top.
+            slot = int(instr.arg)
+            if not stack:
+                raise IndexError("LOCAL_TEE on empty stack")
+            locals_[slot] = stack[-1]
         else:  # pragma: no cover — guarded by _SCOPE_OPS_MOD above
             raise BlockedOpcodeForSymbolic(f"unreachable: op {op}")
 


### PR DESCRIPTION
Closes #105.

## Summary

Extends both bilinear-FF dispatches in `ff_symbolic.py` — the Poly-over-ℤ driver (`evaluate_program`) and the mod-2³² driver (`evaluate_program_mod`) — with `LOCAL_GET` / `LOCAL_SET` / `LOCAL_TEE` handlers. Each driver now carries its own `locals_` table alongside the stack.

The three sibling sites called out in the issue are now aligned:
- ✅ `symbolic_executor._POLY_OPS` and `run_symbolic` dispatch (#102)
- ✅ `_apply_poly_op` in `run_forking` + catalog gatekeeper (#104)
- ✅ **`ff_symbolic.py`'s bilinear-FF dispatch (this PR)**

## FF-interpretation invariant

Documented inline at both `_SCOPE_OPS` sites:

> LOCAL slots are transparent to the bilinear FF — a slot just stores and retrieves whatever symbolic value was written, invoking no weight matrix. Each LOCAL_* step routes a single symbolic value through the locals table, so every downstream arithmetic composition still bottoms out at the same `M_ADD` / `M_SUB` / `B_MUL` (etc.) callsite as it would under pure stack manipulation.

The equivalence claim from #69 extends unchanged. The same argument lifts to `ModPoly`: the mod-2³² homomorphism `ModPoly.from_poly ∘ evaluate_program == evaluate_program_mod` holds on the collapsed-Poly catalog, because the locals table only threads already-reduced `ModPoly` values — the `__post_init__` reduction happens at the arithmetic primitive that writes them, not at the GET/SET edge.

## Collateral fix: SUB operand ordering

`gen_mixed_signs` (whose `emit_negate` sequence is the only catalog row that genuinely tests a negative coefficient via SUB) exposed a latent bug: `evaluate_program` and `evaluate_program_mod` were calling `symbolic_sub(a, b)` / `symbolic_sub_mod(a, b)` with `(a = SP-1, b = top)`, but both primitives follow the FF `(pa = top, pb = SP-1)` convention and return `pb - pa`. The call should be `(b, a)` — matching `DIV_S`, `REM_S`, `symbolic_cmp`, and the `FF_ARITHMETIC_OPS.sub` wrapper, which all correctly swap. Fixed in both drivers.

Pre-existing (masked while LOCAL.SET short-circuited `test_equivalence_*`); now required for `test_modpoly_catalog_structural` to actually match the `Poly` side.

## Results

Baseline (`main`): 15 failing checks in `test_ff_symbolic.py`.
After this PR: 10 failing checks.

All five LOCAL-related failures are fixed:
- `test_equivalence_structural` — was `uncaught BlockedOpcodeForSymbolic: LOCAL.SET`
- `test_equivalence_numeric` — same
- `test_modpoly_catalog_structural` — same, mod-2³² variant
- `test_modpoly_catalog_numeric` — same, mod-2³² variant
- `test_modpoly_homomorphism_on_catalog` — same

The remaining 10 failures are pre-existing BitVec operand-order issues (`bitvec.struct.eq[AND/OR/XOR/SHL/SHR_S/SHR_U]`, `bit_extract`, `popcount_loop`, `is_power_of_2.struct.poly`) — unrelated to LOCAL_*, present on `main` before this change, and out of scope for #105.

## Test plan

- [x] `python3 test_ff_symbolic.py` — all LOCAL_*-related checks pass
- [x] `python3 test_symbolic_executor.py` — no regressions
- [x] `python3 test_symbolic_programs_catalog.py` — 40/40
- [x] No token leak in `.git/config` after push