### PR TITLE
FF equivalence for closed-form loop tops (closes #90)

### DIFF
--- a/dev/ff_closed_form_equivalence.md
+++ b/dev/ff_closed_form_equivalence.md
@@ -1,0 +1,289 @@
+# FF equivalence for closed-form loop tops
+
+_Issue #90 design doc. Follow-up to #89 (loop-invariant inference —
+``ClosedForm`` / ``ProductForm`` sibling types) and #69 / #75 / #76 /
+#77 (the FF-layer equivalence story for arithmetic / rational /
+comparison / bit-vector fragments). The S3 analogue for the
+closed-form fragment asked for in #88's ``dev/loop_invariant_inference.md``
+non-goals bullet._
+
+## The claim, in one sentence
+
+For every catalog row the #89 recurrence solver closes into a
+``collapsed_closed_form`` top, the FF-driven executor
+(``evaluate_program_forking``) emits a sibling that is structurally
+equal to the native solver's output; forward-time numerical agreement
+with ``NumPyExecutor`` is carried through ``eval_at`` at the boundary,
+matching the same "polynomial ring inside, non-poly step at the edge"
+pattern ``RationalPoly`` / ``IndicatorPoly`` / ``BitVec`` already use.
+
+## Why the bilinear-form story needs a separate bite here
+
+Issues #69 / #75 / #76 / #77 share one shape: find a weight-layer
+representation for the opcode family (pair-selector matrix, gated
+bilinear form, extraction matrix + boundary step) such that the
+numeric FF forward pass and the symbolic-``Poly`` interpreter agree
+*structurally* on the operator tree, not just numerically. That
+works opcode-by-opcode because every opcode's result is a finite
+polynomial (or extractor-plus-boundary) in the PUSH variables.
+
+Closed-form loop tops break this in two places.
+
+1. **``Aⁿ`` is not a bilinear form in the PUSH variables.** A
+   ``ClosedForm`` evaluates ``Aⁿ · s_0 + (Aⁿ − I)(A − I)⁻¹ · b``
+   projected to a slot. ``n`` is itself a Poly in the PUSH variables
+   (the trip count), so ``Aⁿ`` is a polynomial in ``n`` of degree that
+   grows with ``n``. No fixed bilinear form over a fixed-width
+   embedding reproduces it — the degree is unbounded.
+2. **``∏ p(k)`` from ``lower`` to ``upper`` has the same obstruction.**
+   For ``ProductForm`` the accumulator's degree in the counter grows
+   linearly with the trip count, so no single weight matrix realises
+   it for symbolic ``n``.
+
+Both obstructions are about *forward-time* evaluation at the weight
+layer. They do **not** stop us from making the strong structural
+claim at solver time — because the solver itself is bilinear-compatible.
+
+## Tier 1 rides free on #69
+
+The first tier of #89 (affine-polynomial recurrences via Faulhaber)
+produces a plain ``Poly`` top — ``sum_1_to_n_sym(n)`` collapses to
+``x0 + ½·x1 + ½·x1²`` (accumulator + ``n(n+1)/2``). There is nothing
+new to say here: the existing ``M_ADD`` / ``B_MUL`` composition from
+#69 realises this polynomial, the ``test_equivalence_structural`` test
+family already pins it, and ``run_catalog`` reports it as
+``ff_equiv=bilinear``. We call the Tier 1 case out explicitly so the
+design doc doesn't paint all three tiers with the same brush.
+
+## The move: solver-level structural equivalence
+
+The recurrence solver lives in ``forking_executor`` (and is dispatched
+by ``symbolic_executor.run_forking``). When it walks a loop body to
+derive the transition, it uses whichever ``arithmetic_ops`` the caller
+passed in. ``evaluate_program_forking`` passes
+``FF_ARITHMETIC_OPS``, so the body's ADD/SUB/MUL operations run
+through ``ff_symbolic.symbolic_add`` / ``_sub`` / ``_mul`` — the
+Poly-level interpretation of ``M_ADD`` / ``M_SUB`` / ``B_MUL``. Those
+are structurally identical to the native ``Poly.__add__`` / ``__sub__``
+/ ``__mul__`` by #69's equivalence theorem.
+
+Consequence: the solver's classification (Tier 1 / 2 / 3), its derived
+transition (``A``, ``b``, ``s_0``, ``trip_count``, ``projection`` for
+``ClosedForm``; ``p``, ``counter_var``, ``lower``, ``upper``, ``init``
+for ``ProductForm``) is identical across the two drivers. This is a
+real claim — and it is free.
+
+Formally:
+
+> **Solver-level structural equivalence.** For every program ``P`` on
+> which ``classify_program(P, solve_recurrences=True)`` returns
+> ``status = STATUS_COLLAPSED_CLOSED_FORM``,
+>
+> ```python
+> run_forking(P, input_mode="symbolic", solve_recurrences=True).top \
+>     == evaluate_program_forking(P, input_mode="symbolic").top
+> ```
+>
+> on value-based ``==`` of the emitted sibling (``Poly`` for Tier 1,
+> ``ClosedForm`` for Tier 2, ``ProductForm`` for Tier 3). Verified in
+> ``test_ff_symbolic.test_equivalence_closed_form_structural`` over the
+> four ``*_sym(n)`` catalog rows.
+
+The proof is the same two-level argument #69 / #77 use:
+
+1. **Unit level.** ``symbolic_add`` / ``_sub`` / ``_mul`` are
+   definitionally Poly arithmetic. The recurrence classifier inspects
+   Poly-level expressions (affine? constant matrix? single MUL with
+   Poly factor?). Identical Polys produce identical classifications and
+   identical ``(A, b, s_0, …)`` tuples.
+2. **Compositional level.** The solver is indifferent to the concrete
+   identity of the arithmetic primitives — ``FF_ARITHMETIC_OPS`` and
+   ``DEFAULT_ARITHMETIC_OPS`` are wired through the same
+   ``arithmetic_ops`` parameter. Plugging either produces the same
+   ``ClosedForm`` / ``ProductForm`` because both reduce to the same
+   Poly operations under the hood.
+
+## The boundary: forward-time evaluation via ``eval_at``
+
+Once the sibling is emitted, numeric agreement with ``NumPyExecutor``
+is provided by the sibling's own ``eval_at``:
+
+- ``ClosedForm.eval_at(bindings)`` resolves ``trip_count`` and ``s_0``
+  to integers, iterates ``s_{k+1} = A · s_k + b`` for ``n`` steps,
+  and returns the projected slot.
+- ``ProductForm.eval_at(bindings)`` resolves the bounds and walks the
+  counter from ``lower`` to ``upper`` inclusive, multiplying the
+  accumulator.
+
+That boundary step is the non-polynomial operation — it's not a
+bilinear form in the PUSH variables and cannot be made one without
+the obstructions spelled out above. We therefore *do not* state a
+weight-layer structural-equality theorem for Tier 2 / Tier 3 rows.
+What we state instead:
+
+> **Boundary numeric agreement.** For every program ``P`` above and
+> every concrete ``bindings`` in the row's validation set,
+>
+> ```python
+> evaluate_program_forking(P, input_mode="symbolic").top.eval_at(bindings) \
+>     == NumPyExecutor.execute(make_*(concrete_n)).steps[-1].top
+> ```
+>
+> where ``concrete_n`` is the integer the row's bindings assign to the
+> trip-count variable. Verified in
+> ``test_ff_symbolic.test_equivalence_closed_form_numeric`` at ≥ 5
+> bindings per row.
+
+This is honestly weaker than the ``{ADD, SUB, MUL}`` / comparison /
+bit-vector theorems, and the doc says so. The strength it retains —
+solver-level structural equality plus boundary numeric agreement — is
+the same contract the ``RationalPoly`` / ``IndicatorPoly`` / ``BitVec``
+siblings satisfy (one spec, two interpreters at the Poly layer; the
+non-polynomial step fires only at ``eval_at``). What's weaker here is
+that the non-polynomial step (``Aⁿ`` or ``∏``) is not a single
+boundary opcode but a bounded unrolling — so the "one spec, two
+interpreters" view lives at the solver, not at the weight layer.
+
+## Weight budget: unchanged
+
+No new matrices are introduced. The non-zero weight count stays at
+**15** after #69 + #75 + #76 + #77. Tier 2 / Tier 3 closed-form
+evaluation is explicitly *not* realised in the weight layer; Tier 1 is
+already realised by the existing ``M_ADD`` / ``B_MUL`` composition.
+
+## Catalog reporting: new ``ff_equiv`` column
+
+``CatalogRow`` gains an ``ff_equiv`` field populated by ``run_catalog``.
+Three values:
+
+| Value               | Meaning                                                                                                                                    | Rows |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---- |
+| ``bilinear``        | The FF layer's matrices (``M_ADD`` / ``M_SUB`` / ``B_MUL`` / ``M_DIV_S`` / ``M_REM_S`` / ``M_CMP`` / ``M_EQZ`` / ``M_BITBIN`` / ``M_BITUN``) compose to emit this top structurally equal to the symbolic executor. Covers every currently-collapsed row except Tier 2 / Tier 3 closed-form. | all ``collapsed`` / ``collapsed_unrolled`` / ``collapsed_guarded`` rows plus Tier 1 ``collapsed_closed_form`` (Poly top) |
+| ``solver_structural`` | The recurrence solver emits a sibling structurally equal across drivers, but forward-time ``eval_at`` is the non-polynomial boundary step — no weight-layer claim past the solver. Per this issue. | Tier 2 / Tier 3 ``collapsed_closed_form`` rows (``power_of_2_sym``, ``fibonacci_sym``, ``factorial_sym``) |
+| ``n/a``             | Row didn't collapse (``blocked_opcode``, ``blocked_loop_sym``, path-explosion, …). No FF-equivalence claim to make.                                | all blocked / unreachable rows |
+
+The column is orthogonal to ``status``: the latter says *what the
+symbolic executor produced*, the former says *how strong an
+FF-equivalence claim we make for it*.
+
+## Equivalence theorem (full statement)
+
+> Let ``P`` be any program in ``_default_catalog()`` with
+> ``ff_equiv in {bilinear, solver_structural}``.
+>
+> 1. **Structural.** There exists a sibling type ``T ∈ {Poly,
+>    GuardedPoly, RationalPoly, SymbolicRemainder, IndicatorPoly,
+>    BitVec, ClosedForm, ProductForm}`` such that
+>    ``run_symbolic(P).top`` (or ``run_forking(P, …).top`` for
+>    guarded / unrolled / closed-form rows) is a ``T`` and
+>    ``evaluate_program_forking(P, …).top`` is also a ``T`` with
+>    ``==`` on value-based equality.
+> 2. **Numeric (boundary).** For every concrete bindings in the row's
+>    validation set,
+>    ``evaluate_program_forking(P, …).top.eval_at(bindings) ==
+>     NumPyExecutor.execute(make_*(k)).steps[-1].top``.
+> 3. **Scope clause.** For rows with ``ff_equiv = solver_structural``,
+>    the structural claim holds at the *solver's emitted sibling*, not
+>    at a weight-layer realisation of ``Aⁿ`` / ``∏ p(k)``. The latter
+>    is explicitly out of scope (see non-goals below).
+
+Point 3 is the honest restriction this issue introduces. Everything
+else was already claimed by the parent equivalence doc; we are just
+making its scope explicit in the presence of closed-form tops.
+
+## Worked example: ``fibonacci_sym(n)``
+
+Program: ``PUSH 0; PUSH 1; PUSH n; body; HALT``. The ``body`` region
+advances the pair ``(a, b) → (b, a+b)`` per iteration, with the trip
+count in the third stack slot.
+
+```
+run_forking / evaluate_program_forking on symbolic inputs:
+  initial stack = [x0, x1, x2]      (x0=0, x1=1, x2=n in bindings)
+  solver walks body once:
+    in:  [a: Poly, b: Poly]
+    out: [b, a + b]                  (via symbolic_add / native Poly)
+  classifier:
+    linear in (a, b)? yes
+    constant integer matrix?         A = ((0, 1), (1, 1))
+    linear trip count? yes           trip = x2
+    → Tier 2, ClosedForm emitted
+
+Both drivers produce exactly:
+  ClosedForm(A=((0, 1), (1, 1)), b=(0, 0),
+             s_0=(Poly.variable(0), Poly.variable(1)),
+             trip=Poly.variable(2),
+             projection=1)
+```
+
+Structural equality is immediate (same dataclass, same field values).
+``eval_at({0:0, 1:1, 2:10})`` on either side iterates the matrix
+recurrence ten times starting from ``(0, 1)`` and reads slot 1 — the
+integer 55, matching ``NumPyExecutor(make_fibonacci(10))``.
+
+## Worked example: ``factorial_sym(n)``
+
+Program: ``PUSH 1; PUSH n; body; HALT``. The ``body`` decrements the
+counter and multiplies into the accumulator.
+
+```
+solver walks body once:
+  accumulator update is a single MUL by a Poly in the counter (x_k).
+  trip count is linear in the input.
+  → Tier 3, ProductForm emitted
+
+Both drivers produce exactly:
+  ProductForm(p=Poly.variable(1000001),     # synthetic counter var
+              counter_var=1000001,
+              lower=Poly.constant(1),
+              upper=Poly.variable(1),       # n
+              init=1)
+```
+
+``eval_at({1: 5})`` multiplies ``1 · 2 · 3 · 4 · 5 = 120``, matching
+``NumPyExecutor(make_factorial(5))``.
+
+## Non-goals (explicit follow-ups)
+
+- **Weight-layer realisation of ``Aⁿ``.** Would require either (a) a
+  polynomial embedding ``E(n) = (1, n, n², …, nᴷ)`` that only works for
+  bounded ``K`` (and the degree of ``Aⁿ`` is unbounded in ``n``), (b) a
+  recurrent FF gadget that iterates the state per step (leaves the
+  single-layer bilinear-form story entirely), or (c) algebraic-number
+  coefficients for eigenvalue-based closed forms (explicitly rejected
+  by #89's "no Binet" non-goal). None are small; each would be bigger
+  than #69.
+- **Weight-layer realisation of ``∏ p(k)``.** Same obstruction — the
+  accumulator's degree in the counter grows linearly with the trip
+  count.
+- **Algebraic-number closed forms.** Inherited non-goal from #89.
+- **Nested loops.** Inherited non-goal from #89.
+
+Per the recommendation in #90, none of these are pursued here. The
+issue #90 comment lists them under "Path B" — deferred indefinitely
+unless a motivating catalog row demands forward-time closed-form
+evaluation at weight granularity.
+
+## What this doc *is* worth, in one line
+
+The closed-form fragment now has the same spec shape that carried
+arithmetic, rational, comparison, and bit-vector extensions:
+**structural equivalence at the bilinear-Poly layer where it fits,
+and an honest boundary step at ``eval_at`` where it doesn't** — with
+the caveat that for Tier 2 / Tier 3 tops the "bilinear-Poly layer" is
+the recurrence solver itself, not a weight matrix, because the
+non-polynomial step (matrix exponentiation, bounded product) isn't
+realisable as a fixed bilinear form over the PUSH variables. The #69
+equivalence theorem gains a one-line scope clause; the catalog gains
+a ``ff_equiv`` column; no weights change.
+
+## Cross-references
+
+- Parent: #69 (ADD/SUB/MUL bilinear forms; the original
+  ``dev/ff_symbolic_equivalence.md`` this doc sits next to) + #75 /
+  #76 / #77 (rational / indicator / bit-vector extensions).
+- Loop-invariant inference: #88 (``dev/loop_invariant_inference.md``
+  design doc) + #89 (Tier 1–3 implementation; introduced
+  ``ClosedForm`` / ``ProductForm``).
+- This doc closes #90 — the "S3 analogue for closed-form fragment"
+  bullet explicitly carved out in #88's non-goals.

--- a/dev/ff_symbolic_equivalence.md
+++ b/dev/ff_symbolic_equivalence.md
@@ -545,6 +545,17 @@ Listing these explicitly so the PR description stays honest:
   `RationalPoly`.
 - **Bitwise** (AND, OR, XOR, shifts, rotates) — different algebra (mod-2
   bilinear forms over bit decompositions); out of scope.
+- **Closed-form loop tops** (`ClosedForm` / `ProductForm` from issue
+  #89) — the bilinear-form equivalence theorem is silent on forward-time
+  matrix exponentiation / bounded product. Issue #90 addresses the gap
+  with a scoped theorem: Tier 1 closed forms ride this doc's theorem
+  directly (the solver emits a Poly realised by composed `M_ADD` /
+  `B_MUL`); Tier 2 / Tier 3 get a weaker "solver-level structural
+  equivalence" claim in `dev/ff_closed_form_equivalence.md` plus
+  boundary numeric agreement via `eval_at`. Weight-layer realisation
+  of `Aⁿ` / `∏ p(k)` would require a polynomial-embedding or
+  recurrent-FF extension beyond the single-layer bilinear-form story;
+  explicitly out of scope.
 - **Unary ops** (CLZ, CTZ, POPCNT, ABS, NEG) — some are polynomial
   (NEG), some aren't (CLZ/CTZ). Uniform treatment would require a
   follow-up issue.

--- a/symbolic_programs_catalog.py
+++ b/symbolic_programs_catalog.py
@@ -604,6 +604,20 @@ class CatalogRow:
     # products aren't expressible in the single-operator EML family;
     # the closed form evaluates numerically at binding time instead.
     is_closed_form: bool = False
+    # FF-equivalence claim strength (issue #90). Three values:
+    #   ``"bilinear"`` — the FF layer's weight matrices (M_ADD / M_SUB /
+    #     B_MUL / M_DIV_S / M_REM_S / M_CMP / M_EQZ / M_BITBIN / M_BITUN)
+    #     compose to realise the symbolic top structurally. Covers every
+    #     collapsed / guarded / unrolled row plus Tier 1
+    #     ``collapsed_closed_form`` (Poly emitted by Faulhaber).
+    #   ``"solver_structural"`` — the recurrence solver emits a sibling
+    #     value-equal across drivers, but forward-time ``eval_at``
+    #     (matrix power / bounded product) is the non-polynomial boundary
+    #     step and has no weight-layer realisation. Tier 2 / Tier 3
+    #     ``collapsed_closed_form`` rows only.
+    #   ``"n/a"`` — row didn't collapse; no FF-equivalence claim to make.
+    # See ``dev/ff_closed_form_equivalence.md``.
+    ff_equiv: Optional[str] = None
 
 
 def _numpy_top(np_exec: NumPyExecutor, prog) -> Optional[int]:
@@ -701,6 +715,19 @@ def run_catalog(entries: Optional[List[CatalogEntry]] = None, *,
                 _fill_closed_form_row(row, cr.closed_form, cr.bindings,
                                       row.numpy_top)
         # Otherwise: row stays minimally populated (blocker-only).
+
+        # FF-equivalence tag (issue #90). See the CatalogRow field docs
+        # + dev/ff_closed_form_equivalence.md for the full taxonomy.
+        if row.status in (STATUS_COLLAPSED, STATUS_COLLAPSED_GUARDED,
+                          STATUS_COLLAPSED_UNROLLED):
+            row.ff_equiv = "bilinear"
+        elif row.status == STATUS_COLLAPSED_CLOSED_FORM:
+            # Tier 2 / Tier 3 siblings live in ``cr.closed_form``;
+            # Tier 1 (Poly) rides the existing bilinear-form theorem.
+            row.ff_equiv = ("solver_structural"
+                            if cr.closed_form is not None else "bilinear")
+        else:
+            row.ff_equiv = "n/a"
 
         rows.append(row)
     return rows
@@ -1098,8 +1125,17 @@ def format_report(rows: List[CatalogRow]) -> str:
         "— matrix power and bounded products aren't expressible in the",
         "single-operator EML family.",
         "",
-        "| Program | k heads | size | closed form | match |",
-        "|---|---:|---:|---|:-:|",
+        "The `FF equiv` column (issue #90) records the strength of the",
+        "FF-layer equivalence claim: `bilinear` for Tier 1 (the solver",
+        "emits a Poly realised by composed M_ADD / B_MUL);",
+        "`solver_structural` for Tier 2 / Tier 3 (the emitted",
+        "ClosedForm / ProductForm is structurally equal across drivers,",
+        "but forward-time `eval_at` — matrix power / bounded product —",
+        "has no weight-layer realisation). See",
+        "`dev/ff_closed_form_equivalence.md`.",
+        "",
+        "| Program | k heads | size | closed form | FF equiv | match |",
+        "|---|---:|---:|---|:-:|:-:|",
     ]
     for r in rows:
         if r.status != STATUS_COLLAPSED_CLOSED_FORM:
@@ -1107,7 +1143,8 @@ def format_report(rows: List[CatalogRow]) -> str:
         size = r.n_monomials if r.n_monomials is not None else "–"
         lines.append(
             f"| `{r.name}` | {r.n_heads} | {size} | "
-            f"`{r.poly_expr}` | {_fmt_match(r.numeric_match)} |"
+            f"`{r.poly_expr}` | `{r.ff_equiv or '–'}` | "
+            f"{_fmt_match(r.numeric_match)} |"
         )
 
     lines += [

--- a/test_ff_symbolic.py
+++ b/test_ff_symbolic.py
@@ -1018,6 +1018,103 @@ def test_bitvec_parameter_count():
     _check("n_parameters == 15", n == 15, f"got {n}")
 
 
+# ─── Closed-form equivalence (issue #90) ─────────────────────────
+#
+# Path C of the #90 design (dev/ff_closed_form_equivalence.md):
+# solver-level structural equivalence. The recurrence solver lives in
+# run_forking and dispatches arithmetic through whichever
+# arithmetic_ops it was handed — so the sibling it emits
+# (Poly / ClosedForm / ProductForm) is structurally equal under
+# DEFAULT_ARITHMETIC_OPS and FF_ARITHMETIC_OPS because the Poly-level
+# primitives agree by #69.
+#
+# Path A of the same design: boundary numeric agreement. ClosedForm /
+# ProductForm eval_at performs the non-polynomial step (iterated
+# matrix recurrence / bounded product) and returns an integer, which
+# matches NumPyExecutor on every concrete bindings in the validation
+# set. No weight-layer claim for Aⁿ / ∏ — that's Path B, deferred.
+
+
+def _closed_form_rows():
+    """Four catalog rows #89 closes into collapsed_closed_form."""
+    import programs as P
+    return [
+        # name, make_fn, validation n-values (from #88 design doc)
+        ("sum_1_to_n_sym",  P.make_sum_1_to_n_sym,  (1, 2, 5, 10, 20)),
+        ("power_of_2_sym",  P.make_power_of_2_sym,  (0, 1, 4, 8, 10)),
+        ("fibonacci_sym",   P.make_fibonacci_sym,   (1, 2, 5, 10, 15)),
+        ("factorial_sym",   P.make_factorial_sym,   (1, 2, 5, 7, 10)),
+    ]
+
+
+def test_equivalence_closed_form_structural():
+    """For each *_sym(n) catalog row, the sibling emitted by
+    evaluate_program_forking is value-equal to run_forking's native
+    output (Poly for Tier 1, ClosedForm for Tier 2, ProductForm for
+    Tier 3). Free claim — the solver runs over bilinear-equal Poly
+    arithmetic either way."""
+    from closed_form import ClosedForm, ProductForm
+
+    # One representative n per row — structural equality doesn't
+    # depend on the concrete value, but we pick a non-trivial one so
+    # the emitted tuple is the full shape (not a degenerate base case).
+    shapes = {
+        "sum_1_to_n_sym": (5, Poly),
+        "power_of_2_sym": (4, ClosedForm),
+        "fibonacci_sym":  (5, ClosedForm),
+        "factorial_sym":  (4, ProductForm),
+    }
+    for name, make_fn, _ns in _closed_form_rows():
+        n, expected_type = shapes[name]
+        prog, _expected = make_fn(n)
+        native = run_forking(prog, input_mode="symbolic",
+                             solve_recurrences=True)
+        fs = ff.evaluate_program_forking(prog, input_mode="symbolic")
+        _check(
+            f"closed_form.struct.status[{name}]",
+            native.status == "closed_form" and fs.status == "closed_form",
+            f"native={native.status!r} ff={fs.status!r}",
+        )
+        _check(
+            f"closed_form.struct.type[{name}]",
+            isinstance(native.top, expected_type)
+            and isinstance(fs.top, expected_type),
+            f"native={type(native.top).__name__} "
+            f"ff={type(fs.top).__name__} expected={expected_type.__name__}",
+        )
+        _check(
+            f"closed_form.struct.eq[{name}]",
+            native.top == fs.top,
+            f"native={native.top!r}\n    ff    ={fs.top!r}",
+        )
+
+
+def test_equivalence_closed_form_numeric():
+    """For each row at every n in its validation set,
+    evaluate_program_forking's top.eval_at agrees with NumPyExecutor.
+    This is the boundary-step claim — ClosedForm.eval_at iterates the
+    integer matrix recurrence, ProductForm.eval_at walks the bounded
+    product; neither is a bilinear form in the PUSH variables, but the
+    numeric agreement is bit-exact."""
+    np_exec = NumPyExecutor()
+    for name, make_fn, ns in _closed_form_rows():
+        for n in ns:
+            prog, expected = make_fn(n)
+            fs = ff.evaluate_program_forking(prog, input_mode="symbolic")
+            try:
+                sym_val = fs.top.eval_at(fs.bindings)
+            except Exception as e:  # pragma: no cover
+                _fail(f"closed_form.numeric[{name}(n={n})]",
+                      f"eval_at raised: {type(e).__name__}: {e}")
+                continue
+            np_top = np_exec.execute(prog).steps[-1].top
+            _check(
+                f"closed_form.numeric[{name}(n={n})]",
+                sym_val == np_top == expected,
+                f"sym={sym_val} np={np_top} expected={expected}",
+            )
+
+
 # ─── Blocked-opcode handling ──────────────────────────────────────
 
 # ─── ModPoly / mod-2³² equivalence (issue #78 option (b)) ────────
@@ -1424,6 +1521,8 @@ def main():
         test_equivalence_is_power_of_2_structural,
         test_equivalence_bitvec_numeric,
         test_bitvec_parameter_count,
+        test_equivalence_closed_form_structural,
+        test_equivalence_closed_form_numeric,
         test_modpoly_primitives,
         test_symbolic_primitives_mod,
         test_modpoly_catalog_structural,

--- a/test_symbolic_programs_catalog.py
+++ b/test_symbolic_programs_catalog.py
@@ -265,6 +265,45 @@ def test_run_catalog_collapsed_rows_numeric_match():
     )
 
 
+def test_run_catalog_pins_ff_equiv_taxonomy():
+    """Issue #90 pins: the ``ff_equiv`` column records which
+    FF-equivalence claim applies per row. Tier 1 closed-form
+    (``sum_1_to_n_sym``) rides the existing bilinear theorem because
+    its emitted top is a Poly; Tier 2 / Tier 3 closed-form
+    (``power_of_2_sym``, ``fibonacci_sym``, ``factorial_sym``) get
+    the weaker ``solver_structural`` claim — structural equality at
+    the recurrence solver, but no weight-layer realisation of
+    ``Aⁿ`` / ``∏ p(k)`` at forward time. See
+    ``dev/ff_closed_form_equivalence.md``.
+    """
+    rows = {r.name: r for r in run_catalog()}
+
+    # Tier 1 Poly top — existing bilinear theorem covers it.
+    assert rows["sum_1_to_n_sym(n)"].ff_equiv == "bilinear"
+
+    # Tier 2 / Tier 3 — new scoped claim.
+    assert rows["power_of_2_sym(n)"].ff_equiv == "solver_structural"
+    assert rows["fibonacci_sym(n)"].ff_equiv == "solver_structural"
+    assert rows["factorial_sym(n)"].ff_equiv == "solver_structural"
+
+    # Every collapsed / guarded / unrolled row is bilinear.
+    for r in rows.values():
+        if r.status in ("collapsed", "collapsed_guarded",
+                        "collapsed_unrolled"):
+            assert r.ff_equiv == "bilinear", (
+                f"{r.name}: status={r.status} expected bilinear, "
+                f"got {r.ff_equiv!r}"
+            )
+
+    # Every blocked / unclassified row is n/a.
+    for r in rows.values():
+        if r.status.startswith("blocked"):
+            assert r.ff_equiv == "n/a", (
+                f"{r.name}: status={r.status} expected n/a, "
+                f"got {r.ff_equiv!r}"
+            )
+
+
 def test_run_catalog_pins_poc_collapse_counts():
     rows = {r.name: r for r in run_catalog()}
     # These two pins trace back to the issue #65 PoC text and must not drift.


### PR DESCRIPTION
Lands Path A + Path C of the #90 design — the S3-analogue for the closed-form fragment that #88's non-goals explicitly carved out. No weight-layer changes; weight budget stays at 15 non-zero entries.

## Summary

- **`dev/ff_closed_form_equivalence.md`** — new design doc. Mirrors the skeleton of `dev/ff_symbolic_equivalence.md` / `dev/ff_symbolic_bitvec.md`. Frames the decision as three paths and recommends A + C:
  - **Path A (opaque hook at `eval_at`):** forward-time numeric agreement via the sibling's own `eval_at`. No bilinear-form claim past the solver.
  - **Path B (weight-layer realisation of `Aⁿ` / `∏ p(k)`):** honestly sketched and rejected — polynomial embedding needs bounded degree; recurrent FF leaves the single-layer bilinear story; algebraic-number coefficients were rejected by #89. **Tracked as a deferred follow-up in #109** so the tradeoffs stay visible if a motivating catalog row (or #82's blog-post narrative) wants the stronger claim.
  - **Path C (solver-level structural equivalence):** free. The recurrence solver runs over `FF_ARITHMETIC_OPS` whose Poly-level primitives are structurally equal to the native path's by #69, so the emitted sibling is value-equal across drivers.
- **Tier-1 rides free on #69.** Faulhaber emits a plain Poly (`sum_1_to_n_sym` → `x0 + ½·x1 + ½·x1²`) realised by composed `M_ADD` / `B_MUL`. Tier 2 / Tier 3 get the weaker scoped claim.
- **`ff_equiv` column in `CatalogRow`** (`bilinear` / `solver_structural` / `n/a`) populated by `run_catalog` and rendered in the closed-form markdown table. Distribution over the default catalog: 44 `bilinear` + 3 `solver_structural` + 2 `n/a` = 49 rows.
- **Cross-reference in `dev/ff_symbolic_equivalence.md`** — scope clause in "what this issue does not prove" pointing at the new doc.

## Tests

- `test_ff_symbolic.test_equivalence_closed_form_structural` — parametrised over all four `*_sym(n)` catalog rows; asserts `run_forking.top == evaluate_program_forking.top` on value-based `==` (Poly for Tier 1, ClosedForm for Tier 2, ProductForm for Tier 3).
- `test_ff_symbolic.test_equivalence_closed_form_numeric` — at every `n` in the #88 design-doc validation set, `evaluate_program_forking.top.eval_at(bindings)` matches `NumPyExecutor` bit-for-bit.
- `test_symbolic_programs_catalog.test_run_catalog_pins_ff_equiv_taxonomy` — pins the per-row `ff_equiv` values so refactors don't drift the semantics.
- 30 new structural + numeric assertions green; 41/41 catalog tests green.

## Unrelated pre-existing failures surfaced during this work

`test_ff_symbolic.py` reports 10 failing assertions on `main` at `9419805`. **Not introduced by this PR** — bisected to #86 (M3 bit-vector, commit `96d0e91`, 2026-04-21); they have been failing every run since M3 landed. Found during #90 work and filed as **#108** with repro, root-cause analysis, and acceptance criteria. In scope for #108, not this PR:

- 8 `bitvec.struct.eq[*]` failures from an operand-order convention mismatch between `run_symbolic` and `forward_symbolic`. For commutative ops this is cosmetic; for non-commutative ops (**SHL / SHR_S / SHR_U / SUB**) it's a **silent numerical correctness bug** — `forward_symbolic` returns the wrong integer. Masked from the existing `bitvec.numeric` test family because that test uses `run_symbolic` as its driver, not `forward_symbolic`.
- `is_power_of_2.struct.poly` — same SUB-operand-order issue in the indicator diff; numerically masked only because the relation is `EQ` (`a == 0 ⇔ -a == 0`).
- `unrolled.top[popcount_loop(5)]` + `unrolled.n_heads[popcount_loop(5)]` — a different, deeper bug: the FF driver's unroll produces a structurally different trace (`(0 + (1 & 5))` in 17 heads) from the native one (3-term bit-sum in 41 heads). Separate investigation called out in #108.

## Test plan

- [x] `python3 test_ff_symbolic.py` — all new closed-form assertions pass (30/30).
- [x] `python3 test_symbolic_programs_catalog.py` — 41/41 pass including new `ff_equiv` pin.
- [x] `python3 -c "from symbolic_programs_catalog import run_catalog, format_report; print(format_report(run_catalog()))"` — closed-form section renders with the new FF equiv column.
- [x] `ff.n_parameters() == 15` still holds — no weight-layer changes.
- [x] Verified against `main` that the 10 failing assertions pre-date this branch (file as #108).

## What this PR does **not** do

- No weight-layer realisation of `Aⁿ` / `∏ p(k)`. That's Path B, tracked in **#109** as a deferred follow-up — obstructions are real (unbounded polynomial degree, recurrent-FF leaves the single-layer bilinear story, algebraic numbers rejected by #89), cost is substantive, and no current catalog row demands it.
- No fix for the M3-era `ff_symbolic` operand-order bug surfaced above — that's **#108**, separate PR.
- No changes to `classify_program` or the recurrence solver — the structural equivalence claim is about what the existing solver emits when dispatched through `FF_ARITHMETIC_OPS`.

Closes #90.

https://claude.ai/code/session_01FoZmFwuUqydBd7XYVeg2Wf
