### PR TITLE
Fix #108: operand-order inversion in ff_symbolic bit-vector dispatch

### DIFF
--- a/ff_symbolic.py
+++ b/ff_symbolic.py
@@ -748,26 +748,31 @@ FF_ARITHMETIC_OPS = ArithmeticOps(
     cmp_le_s=lambda a, b: symbolic_cmp(b, a, isa.OP_LE_S),
     cmp_ge_s=lambda a, b: symbolic_cmp(b, a, isa.OP_GE_S),
     eqz=lambda a: symbolic_eqz(a),
-    # Bit-vector primitives (issue #77). Arg convention matches the
-    # rest: ``a`` = top, ``b`` = SP-1. ``symbolic_bit_*`` takes
-    # ``(pa, pb, op)`` in FF order (pa=top, pb=SP-1), so we pass
-    # ``(b, a)`` where relevant. Unary bit ops pass the single operand
-    # straight through.
-    bit_and=lambda a, b: symbolic_bit_binary(a, b, isa.OP_AND),
-    bit_or=lambda a, b: symbolic_bit_binary(a, b, isa.OP_OR),
-    bit_xor=lambda a, b: symbolic_bit_binary(a, b, isa.OP_XOR),
-    bit_shl=lambda a, b: symbolic_bit_binary(a, b, isa.OP_SHL),
-    bit_shr_s=lambda a, b: symbolic_bit_binary(a, b, isa.OP_SHR_S),
-    bit_shr_u=lambda a, b: symbolic_bit_binary(a, b, isa.OP_SHR_U),
+    # Bit-vector primitives (issue #77). The forking executor's convention
+    # is ``op(a, b)`` with ``a`` = SP-1 and ``b`` = top (same as the Poly
+    # primitives above). ``symbolic_bit_binary`` / ``symbolic_bit_arith``
+    # take ``(pa, pb, op)`` in FF order (pa=top, pb=SP-1) and store them
+    # as ``(pb, pa) = (SP-1, top)`` = PUSH order, so we pass ``(b, a)``
+    # — identical flip to the ``sub`` / ``div_s`` / ``cmp_*`` wrappers
+    # above. Passing ``(a, b)`` unswapped (the pre-#108 bug) put operands
+    # in ``(top, SP-1)`` order, silently breaking non-commutative ops
+    # like SHL (`3 << 2` returned `16` instead of `12`).
+    bit_and=lambda a, b: symbolic_bit_binary(b, a, isa.OP_AND),
+    bit_or=lambda a, b: symbolic_bit_binary(b, a, isa.OP_OR),
+    bit_xor=lambda a, b: symbolic_bit_binary(b, a, isa.OP_XOR),
+    bit_shl=lambda a, b: symbolic_bit_binary(b, a, isa.OP_SHL),
+    bit_shr_s=lambda a, b: symbolic_bit_binary(b, a, isa.OP_SHR_S),
+    bit_shr_u=lambda a, b: symbolic_bit_binary(b, a, isa.OP_SHR_U),
     bit_clz=lambda a: symbolic_bit_unary(a, isa.OP_CLZ),
     bit_ctz=lambda a: symbolic_bit_unary(a, isa.OP_CTZ),
     bit_popcnt=lambda a: symbolic_bit_unary(a, isa.OP_POPCNT),
-    # Hybrid arithmetic: at this callsite ``a`` = top, ``b`` = SP-1
-    # (mirroring how the Poly path calls ``sub(b, a)`` = ``b − a``).
-    # ``symbolic_bit_arith`` does the same swap internally.
-    bit_add=lambda a, b: symbolic_bit_arith(a, b, isa.OP_ADD),
-    bit_sub=lambda a, b: symbolic_bit_arith(a, b, isa.OP_SUB),
-    bit_mul=lambda a, b: symbolic_bit_arith(a, b, isa.OP_MUL),
+    # Hybrid arithmetic lifted into the BitVec AST — same flip as above,
+    # for the same reason. Under the pre-#108 bug the commutative cases
+    # (ADD / MUL) were cosmetically wrong (structural-equality failure
+    # only); SUB was also silently numerically wrong.
+    bit_add=lambda a, b: symbolic_bit_arith(b, a, isa.OP_ADD),
+    bit_sub=lambda a, b: symbolic_bit_arith(b, a, isa.OP_SUB),
+    bit_mul=lambda a, b: symbolic_bit_arith(b, a, isa.OP_MUL),
 )
 
 
@@ -936,10 +941,15 @@ def evaluate_program(prog) -> SymbolicForwardResult:
             else:
                 ai = _require_int_ast(a, name); bi = _require_int_ast(b, name)
                 # is_power_of_2 composes POPCNT (BitVec) with PUSH 1 (Poly).
-                # Build the (vb − va) = (b − a) difference as a BitVec AST
-                # and wrap in IndicatorPoly; matches the poly path's semantics.
+                # Build the (vb − va) difference as a BitVec AST in PUSH
+                # order (operands[0] = SP-1 = vb, operands[1] = top = va)
+                # so ``_apply_bitop("SUB", [vb, va])`` returns ``vb − va``
+                # and matches the Poly path's ``symbolic_cmp(b, a).poly =
+                # pb − pa = SP-1 − top``. Pre-#108 this stored
+                # ``(bi, ai) = (top, SP-1)``, inverting the sign — masked
+                # for EQ (``x == 0 ⇔ −x == 0``), but wrong for LT/LE/GT/GE.
                 stack.append(IndicatorPoly(
-                    poly=BitVec(op="SUB", operands=(bi, ai)),
+                    poly=BitVec(op="SUB", operands=(ai, bi)),
                     relation=_OP_RELATION[op],
                 ))
         elif op == isa.OP_EQZ:
@@ -950,13 +960,16 @@ def evaluate_program(prog) -> SymbolicForwardResult:
                 ai = _require_int_ast(a, "EQZ")
                 stack.append(IndicatorPoly(poly=ai, relation=REL_EQ))
         elif op in _BITBIN_OP_NAME:
-            # Binary bit op (issue #77). Same pop order as arithmetic:
-            # a = top, b = SP-1. ``symbolic_bit_binary`` takes (pa=top,
-            # pb=SP-1) and stores (left=SP-1, right=top) in the AST.
+            # Binary bit op (issue #77). ``_pop()`` order: ``b`` = top,
+            # ``a`` = SP-1. ``symbolic_bit_binary`` takes ``(pa=top,
+            # pb=SP-1)`` and stores ``(pb, pa) = (SP-1, top)`` = PUSH
+            # order, so we pass ``(b, a)``. Pre-#108 passed ``(a, b)``,
+            # producing ``(top, SP-1)`` — silently wrong for
+            # non-commutative ops (SHL ``3 << 2`` returned ``16``).
             name = isa.OP_NAMES.get(op, f"?{op}")
             b = _require_int_ast(_pop(), name)
             a = _require_int_ast(_pop(), name)
-            stack.append(symbolic_bit_binary(a, b, op))
+            stack.append(symbolic_bit_binary(b, a, op))
         elif op in _BITUN_OP_NAME:
             name = isa.OP_NAMES.get(op, f"?{op}")
             a = _require_int_ast(_pop(), name)

--- a/test_ff_symbolic.py
+++ b/test_ff_symbolic.py
@@ -967,6 +967,52 @@ def test_equivalence_is_power_of_2_structural():
     _check("is_power_of_2.struct.rel", sym.top.relation == fs.top.relation)
 
 
+def test_forward_symbolic_bitvec_numeric():
+    """Issue #108 guardrail. Uses ``CompiledModel.forward_symbolic`` as the
+    *driver under test* (not ``run_symbolic``) and cross-checks against
+    ``NumPyExecutor`` — the original ``test_equivalence_bitvec_numeric``
+    below reads ``run_symbolic`` for its ``sym_val``, so a silently wrong
+    ``forward_symbolic`` result (like the SHL ``3 << 2 = 16`` bug that
+    sat on main from M3 until #108) was invisible to the numeric family.
+
+    Non-commutative ops (SHL / SHR_S / SHR_U) and the hybrid-BitVec SUB
+    path are the load-bearing cases — they'd regress silently without a
+    forward_symbolic-driven numeric cross-check.
+    """
+    import programs as P
+    model = CompiledModel()
+    np_exec = NumPyExecutor()
+
+    cases = [
+        ("bitwise_and(12,10)",  P.make_bitwise_binary(isa.OP_AND, 12, 10)),
+        ("bitwise_or(12,10)",   P.make_bitwise_binary(isa.OP_OR, 12, 10)),
+        ("bitwise_xor(12,10)",  P.make_bitwise_binary(isa.OP_XOR, 12, 10)),
+        ("bitwise_shl(3,2)",    P.make_bitwise_binary(isa.OP_SHL, 3, 2)),
+        ("bitwise_shr_s(-4,1)", P.make_bitwise_binary(isa.OP_SHR_S, -4, 1)),
+        ("bitwise_shr_u(-1,4)", P.make_bitwise_binary(isa.OP_SHR_U, -1, 4)),
+        ("native_clz(16)",      P.make_native_clz(16)),
+        ("native_ctz(8)",       P.make_native_ctz(8)),
+        ("native_popcnt(13)",   P.make_native_popcnt(13)),
+        ("bit_extract(5,0)",    P.make_bit_extract(5, 0)),
+        ("log2_floor(8)",       P.make_log2_floor(8)),
+        ("is_power_of_2(8)",    P.make_is_power_of_2(8)),
+    ]
+    for name, (prog, _expected) in cases:
+        try:
+            fs = model.forward_symbolic(prog)
+            ff_val = fs.top.eval_at(fs.bindings)
+        except Exception as e:  # pragma: no cover
+            _fail(f"ff.bitvec.numeric[{name}]",
+                  f"forward_symbolic.eval_at raised: {type(e).__name__}: {e}")
+            continue
+        np_top = np_exec.execute(prog).steps[-1].top
+        _check(
+            f"ff.bitvec.numeric[{name}]",
+            ff_val == np_top,
+            f"forward_symbolic={ff_val}  NumPyExecutor={np_top}",
+        )
+
+
 def test_equivalence_bitvec_numeric():
     """Three-way check: ``sym.top.eval_at == NumPy top == TorchExecutor top``
     for every bit-vector row. Ensures M_BITBIN / M_BITUN realise the same
@@ -1423,6 +1469,7 @@ def main():
         test_equivalence_bitvec_nested_structural,
         test_equivalence_is_power_of_2_structural,
         test_equivalence_bitvec_numeric,
+        test_forward_symbolic_bitvec_numeric,
         test_bitvec_parameter_count,
         test_modpoly_primitives,
         test_symbolic_primitives_mod,


### PR DESCRIPTION
Fixes the silent numerical correctness bug from #108. `forward_symbolic` / `evaluate_program_forking` were returning wrong integers for non-commutative bit ops (SHL / SHR_S / SHR_U / SUB-inside-indicator) because two dispatch sites in `ff_symbolic.py` called the bit-op constructors with operands in the wrong order relative to the `symbolic_bit_binary(pa=top, pb=SP-1)` contract.

## Root cause (one sentence)

The forking executor's `ArithmeticOps` convention is `op(a, b)` with `a = SP-1, b = top`. `symbolic_bit_binary` / `symbolic_bit_arith` take arguments in FF order (`pa = top, pb = SP-1`) and internally store `(pb, pa) = (SP-1, top)` = PUSH order. Both FF dispatch sites were passing `(a, b)` unswapped — identical pattern to what `sub` / `div_s` / `rem_s` / `cmp_*` correctly handle by flipping to `(b, a)`. The bit-op wrappers forgot the flip.

## Impact before this PR

| Op family | Behaviour |
|---|---|
| AND / OR / XOR | Structural-equality failure only; numeric result correct (commutative) |
| SHL / SHR_S / SHR_U | **Silent wrong integer.** `PUSH 3; PUSH 2; SHL` returned `16` (`2 << 3`), not `12` (`3 << 2`) |
| `bit_extract`, `log2_floor` | Wrong integer via nested non-commutative composition |
| SUB under `IndicatorPoly` + `BitVec` hybrid | Sign flip on the diff; masked for `EQ` because `x == 0 ⇔ −x == 0`, but would be wrong for `LT` / `LE` / `GT` / `GE` |
| `popcount_loop(5)` unroll | Structurally different trace — loop body's bit ops got wrong operand order, cascading into the unroll |

Bug landed in #86 (M3, commit `96d0e91`, 2026-04-21) and sat on `main` for ~3 days. Existing `test_equivalence_bitvec_numeric` didn't catch it because that test reads `run_symbolic` (native) as its driver-under-test — `forward_symbolic` never participated in any numeric cross-check.

## Fix

Three-line-equivalent change across three sites in `ff_symbolic.py`:

1. **`FF_ARITHMETIC_OPS` bit-op wrappers** (lines 756–770) — flip args to `symbolic_bit_binary(b, a, op)` / `symbolic_bit_arith(b, a, op)`, identical to the already-correct `sub` / `cmp_*` / `div_s` wrappers above them.
2. **`evaluate_program` direct bit dispatch** — same flip at the `symbolic_bit_binary` call (used by `CompiledModel.forward_symbolic`, not routed through `FF_ARITHMETIC_OPS`).
3. **IndicatorPoly + BitVec diff construction** — build `BitVec("SUB", operands=(ai, bi))` so `operands[0] = SP-1 = vb`, matching `_apply_bitop("SUB", [vb, va]) = vb − va` = WASM semantics.

`symbolic_bit_binary` / `symbolic_bit_arith` are unchanged — their primitive-level tests (`test_symbolic_bitvec_primitives`) pass without modification. No weight-layer changes; `n_parameters() == 15` stays pinned.

## Guardrail: `test_forward_symbolic_bitvec_numeric`

New test that drives `CompiledModel.forward_symbolic` **directly** (not `run_symbolic`) and cross-checks `eval_at` against `NumPyExecutor` on every bit-vector catalog program. The non-commutative cases (SHL / SHR_S / SHR_U) and hybrid-BitVec SUB (`log2_floor`, `is_power_of_2`) are the load-bearing members — any future operand-order regression in the FF bit dispatch trips this loudly rather than slipping through the structural-only check family.

## Test plan

- [x] All 10 previously-FAIL assertions in `test_ff_symbolic.py` now pass — `bitvec.struct.eq[AND/OR/XOR/SHL/SHR_S/SHR_U]`, `bitvec.nested.eq[bit_extract(5,0)]`, `is_power_of_2.struct.poly`, `unrolled.top[popcount_loop(5)]`, `unrolled.n_heads[popcount_loop(5)]`.
- [x] 12 new `ff.bitvec.numeric[*]` assertions pass.
- [x] Full `test_ff_symbolic.py` suite reports "All checks passed."
- [x] `test_symbolic_programs_catalog.py` — 40/40.
- [x] `test_symbolic_executor.py` — clean.
- [x] Spot-check `forward_symbolic` on `SHL(3, 2)` → `12` (was `16`), `bit_extract(5, 0)` → `1` (was `0`), all matching `NumPyExecutor`.
- [x] `n_parameters() == 15` unchanged.

Closes #108.

https://claude.ai/code/session_01FoZmFwuUqydBd7XYVeg2Wf