### PR TITLE
Add MIT license (closes #64)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Oskar Austegard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Adds MIT license, closing #64.

**Rationale for MIT** (over alternatives):

- **Not GPL/AGPL** — This repo is bridge work between others'' research (Percepta'''s transformer-as-computer claim, polynomial-evaluator connection). Copyleft would obstruct the freedom for source researchers to fold improvements back in.
- **Not CC0/Unlicense** — Attribution is the contribution here. The discoveries belong to others; the connective implementation is what should be credited. MIT preserves that paper trail.
- **Not Apache 2.0** — Extra complexity (patent grant, contributor terms) earns its keep on projects with corporate contributors or patent exposure. Neither applies.

MIT is the default for research-validation repos in this genre for the right reasons: three paragraphs, no ambiguity, permissive enough that anyone can build on it commercially or academically.

Closes #64.