### PR TITLE
specialize: partial-evaluation pass (closes #113)

### DIFF
--- a/programs.py
+++ b/programs.py
@@ -146,6 +146,24 @@ def make_fibonacci(n):
     return prog, fib(n)
 
 
+
+def make_countdown(n):
+    """Simplest possible loop: decrement a counter from n to 0. Terminates at 0.
+
+    Canonical specialization demo target -- small, clearly deterministic,
+    traces are easy to eyeball. Final stack top is always 0.
+    """
+    prog = [
+        Instruction(OP_PUSH, n),   # 0: counter = n
+        Instruction(OP_PUSH, 1),   # 1: decrement
+        Instruction(OP_SUB),       # 2: counter - 1
+        Instruction(OP_DUP),       # 3: copy for JNZ test
+        Instruction(OP_JNZ, 1),    # 4: loop if non-zero
+        Instruction(OP_HALT),      # 5: done
+    ]
+    return prog, 0
+
+
 def make_power_of_2(n):
     """Generate a program that computes 2^n via repeated doubling."""
     if n == 0:

--- a/specialize.py
+++ b/specialize.py
@@ -1,0 +1,153 @@
+"""Program specialization via partial evaluation.
+
+Bakes the compiled stack machine's program table into FFN-style coefficient
+tables, so the fetched opcode/arg at each cursor position is computed from
+a fixed set of step-function neurons rather than from attention over a
+program prefix.
+
+For a program of N instructions, specialization emits:
+
+  - 2N ReGLU step-function neurons realising  1[cursor >= i]  for i in 0..N-1
+    (each indicator needs a gate + up half-neuron under the ReGLU product
+    formulation).
+  - Per fetched field f, a coefficient vector  c = [c0, c1-c0, ..., c_{N-1}-c_{N-2}]
+    such that  f(cursor) = sum_{i=0..N-1} c[i] * 1[cursor >= i].
+
+The sum telescopes to f(prog[cursor]) whenever 0 <= cursor < N, so the
+specialized representation is bit-exact with direct indexing into the
+program table.
+
+Based on the partial-evaluation pass described in
+https://www.percepta.ai/blog/constructing-llm-computer (2026-03-25).
+
+In this repo the "FFN" is ordinary arithmetic -- we are not training weights.
+The demonstration is that at deployment time the prompt shrinks from
+(program || input) to (input), because the fetched fields are now a function
+of the cursor alone.
+"""
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Tuple
+
+from isa import Instruction
+
+
+# Fields baked into FFN coefficients. Matches the (op, arg) shape used by
+# every other layer of the executor.
+FIELDS: Tuple[str, ...] = ("op", "arg")
+
+
+@dataclass
+class SpecializedProgram:
+    """A program represented as FFN coefficient tables instead of a prefix.
+
+    Attributes:
+        n:
+            Number of instructions (and number of step-function neurons).
+        coefficients:
+            Per field, a list of length n where coefficients[f][0] = c0 and
+            coefficients[f][i] = c_i - c_{i-1} for i >= 1. The fetched value
+            at cursor t is sum(coefficients[f][i] * 1[t >= i] for i in 0..n-1).
+        originals:
+            The input instruction list. Retained only so the verification
+            helpers can assert specialized-vs-direct parity; fetch() never
+            consults it.
+    """
+
+    n: int
+    coefficients: Dict[str, List[int]]
+    originals: List[Instruction] = field(default_factory=list)
+
+    def step_neurons(self, cursor: int) -> List[int]:
+        """Return the n step-function activations 1[cursor >= i] for i in 0..n-1."""
+        return [1 if cursor >= i else 0 for i in range(self.n)]
+
+    def fetch(self, cursor: int) -> Tuple[int, int]:
+        """Reconstruct (op, arg) at `cursor` using only the coefficient tables.
+
+        Implements the Percepta expansion
+            f(cursor) = c0 + sum_{i=1..n-1} (c_i - c_{i-1}) * 1[cursor >= i]
+        which telescopes to c_cursor for 0 <= cursor < n. Out-of-range cursors
+        saturate at c_{n-1}, matching WASM's trap-on-overrun semantics when
+        the executor has already halted.
+        """
+        if cursor < 0:
+            return (0, 0)
+        ind = self.step_neurons(cursor)
+        op = sum(c * s for c, s in zip(self.coefficients["op"], ind))
+        arg = sum(c * s for c, s in zip(self.coefficients["arg"], ind))
+        return int(op), int(arg)
+
+    def ffn_rows(self) -> List[Tuple[str, int]]:
+        """Describe the 2N ReGLU neurons emitted for this program.
+
+        Each instruction i contributes a (gate, up) pair; their product
+        realises 1[cursor >= i] (the gate saturates at 1, the up saturates
+        at 1, ReGLU multiplies them).
+        """
+        rows: List[Tuple[str, int]] = []
+        for i in range(self.n):
+            rows.append(("gate", i))
+            rows.append(("up", i))
+        return rows
+
+    def token_savings(self, input_tokens: int = 0) -> Dict[str, int]:
+        """Compare prompt sizes: universal (program || input) vs specialized (input)."""
+        program_tokens = 2 * self.n  # op + arg per instruction
+        return {
+            "universal_prompt_tokens": program_tokens + input_tokens,
+            "specialized_prompt_tokens": input_tokens,
+            "program_tokens_saved": program_tokens,
+        }
+
+
+def specialize(prog: List[Instruction]) -> SpecializedProgram:
+    """Partial-evaluate a program into FFN coefficient tables.
+
+    For each field f, computes:
+        c[0] = f(prog[0])
+        c[i] = f(prog[i]) - f(prog[i-1])    for i > 0
+    so that sum_{i=0..cursor} c[i] = f(prog[cursor]).
+    """
+    # Unpack (prog, expected) tuples returned by programs.make_*
+    if isinstance(prog, tuple) and len(prog) == 2 and isinstance(prog[0], list):
+        prog = prog[0]
+
+    n = len(prog)
+    if n == 0:
+        raise ValueError("Cannot specialize an empty program.")
+
+    coefficients: Dict[str, List[int]] = {}
+    for name in FIELDS:
+        seq = [int(getattr(instr, name)) for instr in prog]
+        row = [seq[0]]
+        for i in range(1, n):
+            row.append(seq[i] - seq[i - 1])
+        coefficients[name] = row
+
+    return SpecializedProgram(n=n, coefficients=coefficients, originals=list(prog))
+
+
+def fetch_fn_from_program(prog: List[Instruction]) -> Callable[[int], Tuple[int, int]]:
+    """Universal-interpreter fetch: direct indexing into the program prefix."""
+
+    def fetch(ip: int) -> Tuple[int, int]:
+        if ip < 0 or ip >= len(prog):
+            return (0, 0)
+        instr = prog[ip]
+        return int(instr.op), int(instr.arg)
+
+    return fetch
+
+
+def verify_fetch_parity(prog: List[Instruction]) -> bool:
+    """Assert specialized.fetch(i) == (prog[i].op, prog[i].arg) for every i."""
+    sp = specialize(prog)
+    direct = fetch_fn_from_program(prog)
+    for i in range(len(prog)):
+        if sp.fetch(i) != direct(i):
+            raise AssertionError(
+                f"specialization mismatch at cursor={i}: "
+                f"specialized={sp.fetch(i)} direct={direct(i)}"
+            )
+    return True

--- a/test_specialize.py
+++ b/test_specialize.py
@@ -1,0 +1,169 @@
+"""Specialization parity tests.
+
+Validates the partial-evaluation pass in `specialize.py` on two axes:
+
+  1. STATIC parity — for every cursor 0 <= t < N, specialized.fetch(t) is
+     bit-exact with (prog[t].op, prog[t].arg). Exhaustive over the program
+     table; stronger than any sampled dynamic check.
+
+  2. EXECUTION equivalence — wrap the program so each NumPyExecutor read
+     goes through specialized.fetch(ip) instead of direct indexing, then
+     verify the full trace (every TraceStep) matches the universal
+     interpreter step-for-step, on the full 42-opcode ISA.
+
+Coverage spans countdown (the specialization demo), `ALL_TESTS` (Phase 4
+baseline), and every Phase 13+ generator used by the forking/closed-form
+paths — arithmetic, comparison, bitwise, call/return, select. If this
+passes, the partial-evaluation pass is safe to drop in anywhere the
+universal fetch path is used.
+"""
+
+import os
+import sys
+from typing import List, Tuple
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from isa import Instruction
+from executor import NumPyExecutor
+from programs import (
+    ALL_TESTS,
+    make_countdown,
+    make_fibonacci, make_factorial, make_power_of_2,
+    make_sum_1_to_n, make_multiply, make_gcd, make_is_even,
+    make_log2_floor, make_compare_binary, make_bitwise_binary,
+    make_select_max,
+)
+from specialize import (
+    SpecializedProgram, specialize, verify_fetch_parity, fetch_fn_from_program,
+)
+
+
+# ─── Program wrapper: routes reads through specialized.fetch ────────
+
+class SpecializedProgram_AsList:
+    """Drop-in replacement for `List[Instruction]` whose `__getitem__`
+    reconstructs the Instruction via `SpecializedProgram.fetch(ip)`.
+
+    NumPyExecutor accesses the program table exclusively through `prog[ip]`
+    and `len(prog)`, so routing reads through this wrapper is enough to run
+    the executor against the FFN-specialized representation with zero
+    changes to executor.py.
+    """
+
+    def __init__(self, sp: SpecializedProgram):
+        self._sp = sp
+
+    def __len__(self):
+        return self._sp.n
+
+    def __getitem__(self, ip: int) -> Instruction:
+        op, arg = self._sp.fetch(ip)
+        return Instruction(op, arg)
+
+    def __iter__(self):
+        for i in range(self._sp.n):
+            yield self[i]
+
+
+# ─── Static parity ──────────────────────────────────────────────────
+
+def _static_parity(name: str, prog: List[Instruction]) -> None:
+    verify_fetch_parity(prog)
+    sp = specialize(prog)
+    assert sp.n == len(prog)
+    # Telescoping sanity: prefix-sum of coefficients recovers original field
+    for field in ("op", "arg"):
+        running = 0
+        for i, c in enumerate(sp.coefficients[field]):
+            running += c
+            assert running == int(getattr(prog[i], field)), (
+                f"{name}: telescoping mismatch for {field} at i={i}"
+            )
+
+
+# ─── Execution equivalence ──────────────────────────────────────────
+
+def _trace_tuples(trace) -> List[Tuple[int, int, int, int]]:
+    return [(s.op, s.arg, s.sp, s.top) for s in trace.steps]
+
+
+def _execution_equiv(name: str, prog: List[Instruction], max_steps: int = 50000) -> int:
+    universal = NumPyExecutor().execute(prog, max_steps=max_steps)
+    specialized_wrapper = SpecializedProgram_AsList(specialize(prog))
+    specialized = NumPyExecutor().execute(specialized_wrapper, max_steps=max_steps)
+
+    u = _trace_tuples(universal)
+    s = _trace_tuples(specialized)
+    assert len(u) == len(s), (
+        f"{name}: step count mismatch: universal={len(u)} specialized={len(s)}"
+    )
+    for i, (a, b) in enumerate(zip(u, s)):
+        assert a == b, f"{name}: trace divergence at step {i}: universal={a} specialized={b}"
+    return len(u)
+
+
+# ─── Token savings sanity ───────────────────────────────────────────
+
+def _token_savings(prog: List[Instruction]) -> dict:
+    sp = specialize(prog)
+    ts = sp.token_savings()
+    assert ts["program_tokens_saved"] == 2 * len(prog)
+    assert ts["universal_prompt_tokens"] == 2 * len(prog)
+    assert ts["specialized_prompt_tokens"] == 0
+    return ts
+
+
+# ─── Runner ─────────────────────────────────────────────────────────
+
+def _unpack(p):
+    return p[0] if isinstance(p, tuple) and len(p) == 2 and isinstance(p[0], list) else p
+
+
+def _check(name: str, prog_or_test) -> None:
+    prog = _unpack(prog_or_test() if callable(prog_or_test) else prog_or_test)
+    _static_parity(name, prog)
+    ts = _token_savings(prog)
+    steps = _execution_equiv(name, prog)
+    print(
+        f"  {name:34s}  N={len(prog):3d}  steps={steps:5d}  "
+        f"saved={ts['program_tokens_saved']:3d} toks"
+    )
+
+
+def main() -> int:
+    print("=" * 72)
+    print("Specialization parity: static fetch + execution equivalence (42-op ISA)")
+    print("=" * 72)
+
+    print("\n── countdown (canonical demo) ──")
+    _check("countdown(5)",  make_countdown(5))
+    _check("countdown(20)", make_countdown(20))
+
+    print("\n── ALL_TESTS (Phase 4 baseline) ──")
+    for tname, tfn in ALL_TESTS:
+        _check(f"all_tests/{tname}", tfn)
+
+    print("\n── Phase 13+ generators ──")
+    _check("fibonacci(10)",       make_fibonacci(10))
+    _check("factorial(5)",        make_factorial(5))
+    _check("power_of_2(6)",       make_power_of_2(6))
+    _check("sum_1_to_n(10)",      make_sum_1_to_n(10))
+    _check("multiply(7, 6)",      make_multiply(7, 6))
+    _check("gcd(48, 18)",         make_gcd(48, 18))
+    _check("is_even(14)",         make_is_even(14))
+    _check("log2_floor(1024)",    make_log2_floor(1024))
+    _check("compare_binary eq",   make_compare_binary("eq", 3, 3))
+    _check("compare_binary lt_s", make_compare_binary("lt_s", -1, 1))
+    _check("bitwise_binary xor",  make_bitwise_binary("xor", 0xF0F0, 0x0FF0))
+    _check("bitwise_binary shl",  make_bitwise_binary("shl", 1, 5))
+    _check("select_max(5, 9)",    make_select_max(5, 9))
+
+    print("\n" + "=" * 72)
+    print("OK — all specialization parity tests passed.")
+    print("=" * 72)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Ports the partial-evaluation pass from [claude-skills#577](https://github.com/oaustegard/claude-skills/pull/577) (which was implemented against the skill's reduced ISA) to the full 42-opcode research ISA in this repo. Closes #113.

The math is identical to Percepta's First Futamura projection: for a program of `N` instructions, emit `2N` ReGLU step-function neurons realising `𝟙[cursor ≥ i]`, plus per-field coefficient vectors so that
```
f(cursor) = c₀ + Σᵢ (cᵢ − cᵢ₋₁)·𝟙[cursor ≥ i]
```
telescopes to `f(prog[cursor])`. At deployment the prompt shrinks from `(program ∥ input)` to `(input)` alone.

## Files

- **`specialize.py`** (new, 153 lines) — `SpecializedProgram`, `specialize(prog)`, `fetch(cursor)`, `verify_fetch_parity()`, `token_savings()`, `ffn_rows()`. Straight port from the skill PR with `from isa_lite` → `from isa`.
- **`programs.py`** — added `make_countdown(n)` (canonical demo target, 17 lines).
- **`test_specialize.py`** (new) — two-axis verification:
  1. **Static parity** — exhaustive check that `specialized.fetch(t) == (prog[t].op, prog[t].arg)` for every `t ∈ [0, N)`.
  2. **Execution equivalence** — wraps `SpecializedProgram` as a drop-in `List[Instruction]` (via `__getitem__` → `Instruction(op, arg)`), runs `NumPyExecutor` against the wrapper, and asserts the full `TraceStep` sequence is identical to the universal interpreter step-for-step.

## Coverage

- `countdown(5)`, `countdown(20)` — the specialization demo
- `ALL_TESTS` (Phase 4 baseline, 10 programs)
- Phase 13+ generators: `fibonacci`, `factorial`, `power_of_2`, `sum_1_to_n`, `multiply`, `gcd`, `is_even`, `log2_floor`, `compare_binary` (eq + lt_s), `bitwise_binary` (xor + shl), `select_max`

That's every opcode the forking/closed-form path exercises. Passing here is strong evidence the pass is ISA-complete — including branches, local/heap access, and CALL/RETURN.

## What's NOT in this PR (scope discipline)

- **`CompiledModel` / `TorchExecutor` weight integration.** The skill PR acknowledged up-front that in a Python executor the "FFN" is ordinary arithmetic, not trained weights — the demonstration is architectural. Extending `CompiledModel` to actually materialize the `2N` step-function neurons as PyTorch weight tensors and running `TorchExecutor` without a program-prefix is the obvious follow-up, but it's a separate, larger change (~`CompiledModel._compile_weights` surgery, hard to review alongside the pass itself). Splitting it out keeps this PR reviewable.
- **`executor.mojo`.** The Mojo executor's fetch path is already direct `List[Int]` indexing (no attention-over-prefix), so specialization offers no Mojo-runtime speedup. Left alone intentionally — same reasoning as the skill PR.

## Acceptance (from #113)

- [x] Pick one existing test program — `countdown(5)`, `countdown(20)`
- [x] Specialize it; verify weights match the non-specialized executor's behavior — `verify_fetch_parity()` + exhaustive static check
- [x] Step-count parity with universal interpreter — `_execution_equiv` asserts full `TraceStep` sequence matches across 25 programs spanning the full 42-op ISA
- [x] Benchmark: token count drop — `token_savings()` reports `2N` program tokens eliminated (countdown → 12 → 0, fibonacci(10) → 38 → 0, etc.)
- [x] No regression on universal-interpreter path — `NumPyExecutor`, `executor.py`, `CompiledModel`, and tests untouched

## Running

```
python test_specialize.py
```

## Background

Related skill PR: [claude-skills#577](https://github.com/oaustegard/claude-skills/pull/577) (reduced-ISA prototype, implementation reference)
Percepta's writeup: https://www.percepta.ai/blog/constructing-llm-computer
Our prior blog posts: https://whtwnd.com/austegard.com/3mgxahx5axp2c, https://muninn.austegard.com/blog/126-million-steps-per-second.html
