### PR TITLE
specialize: materialize 2N step-function neurons as CompiledModel FFN weights (closes #115)

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -454,6 +454,73 @@ class NumPyExecutor:
 
 # ─── Compiled PyTorch Model ──────────────────────────────────────
 
+# Specialization residual dims, appended after the base D_MODEL=51 layout
+# (see isa.py). Only present when the model is built with specialized=sp.
+DIM_FETCHED_OP  = D_MODEL          # 51
+DIM_FETCHED_ARG = D_MODEL + 1      # 52
+D_MODEL_SPECIALIZED = D_MODEL + 2  # 53
+
+
+class SpecializationFFN(nn.Module):
+    """2N step-function ReGLU neurons that materialize a SpecializedProgram.
+
+    Realises  fetched_f(ip) = sum_{i=0..N-1} coef_f[i] * 1[ip >= i]
+    using two ReLU half-neurons per instruction whose difference is the
+    integer-valued indicator:
+
+        A_i = ReLU(ip - i + 1)     (gate row 2i)
+        B_i = ReLU(ip - i)         (up   row 2i+1)
+        A_i - B_i = 1[ip >= i]     for any integer ip >= 0
+
+    W_down accumulates  sum_i coef_f[i] * (A_i - B_i)  into the two
+    fetched residual dims (DIM_FETCHED_OP, DIM_FETCHED_ARG). Coefficients
+    are taken directly from sp.coefficients['op'] and sp.coefficients['arg']
+    -- which already store the telescoping deltas
+    [c0, c1-c0, c2-c1, ...] -- so the sum reconstructs c_ip exactly.
+    """
+
+    def __init__(self, sp, d_model):
+        super().__init__()
+        self.n = sp.n
+        self.d_model = d_model
+        # 2N hidden ReLU neurons, then a 2-row down-projection into
+        # (DIM_FETCHED_OP, DIM_FETCHED_ARG).
+        self.W_in = nn.Linear(d_model, 2 * sp.n, bias=True)
+        self.W_down = nn.Linear(2 * sp.n, 2, bias=False)
+        self.double()
+        self._compile(sp)
+
+    def _compile(self, sp):
+        with torch.no_grad():
+            W_in = torch.zeros(2 * sp.n, self.d_model, dtype=DTYPE)
+            b_in = torch.zeros(2 * sp.n, dtype=DTYPE)
+            for i in range(sp.n):
+                # gate row 2i: ReLU(ip + 1 - i)
+                W_in[2 * i, DIM_IP] = 1.0
+                b_in[2 * i] = 1.0 - float(i)
+                # up row 2i + 1: ReLU(ip - i)
+                W_in[2 * i + 1, DIM_IP] = 1.0
+                b_in[2 * i + 1] = -float(i)
+            self.W_in.weight.copy_(W_in)
+            self.W_in.bias.copy_(b_in)
+
+            W_down = torch.zeros(2, 2 * sp.n, dtype=DTYPE)
+            for i in range(sp.n):
+                c_op = float(sp.coefficients["op"][i])
+                c_arg = float(sp.coefficients["arg"][i])
+                W_down[0, 2 * i]     = c_op    # +c_op * A_i
+                W_down[0, 2 * i + 1] = -c_op   # -c_op * B_i
+                W_down[1, 2 * i]     = c_arg
+                W_down[1, 2 * i + 1] = -c_arg
+            self.W_down.weight.copy_(W_down)
+
+    def forward(self, query_emb):
+        """Return (fetched_op_scalar, fetched_arg_scalar) at this query's ip."""
+        h = torch.relu(self.W_in(query_emb))
+        out = self.W_down(h)
+        return out[0], out[1]
+
+
 class CompiledModel(nn.Module):
     """Compiled transformer with 10 attention heads and linear+nonlinear FF dispatch.
 
@@ -476,9 +543,25 @@ class CompiledModel(nn.Module):
       sp_deltas: per-opcode stack pointer delta
     """
 
-    def __init__(self, d_model=D_MODEL):
+    def __init__(self, d_model=D_MODEL, specialized=None):
         nn.Module.__init__(self)
+        # Specialized models append two residual dims (DIM_FETCHED_OP /
+        # DIM_FETCHED_ARG) so the fetched opcode/arg can be read out of
+        # the residual instead of out of attention over a program prefix.
+        if specialized is not None:
+            assert d_model == D_MODEL, (
+                "specialized=sp expects the default d_model; "
+                "the +2 grow is handled internally."
+            )
+            d_model = D_MODEL_SPECIALIZED
         self.d_model = d_model
+        self.specialized = specialized
+        # d_ffn: number of hidden FF neurons. The base dispatch uses none
+        # (M_top is a direct linear routing). Specialization adds exactly
+        # 2N step-function neurons.
+        self.d_ffn = (2 * specialized.n) if specialized is not None else 0
+        if specialized is not None:
+            assert self.d_model == D_MODEL + 2, "d_model must grow by exactly 2 when specialized"
 
         # Heads 0-4
         self.head_prog_op  = CompiledAttentionHead(d_model, head_dim=2, v_dim=1)
@@ -500,6 +583,14 @@ class CompiledModel(nn.Module):
         self.register_buffer('sp_deltas', torch.zeros(N_OPCODES, dtype=DTYPE))
 
         self._compile_weights()
+
+        # Built last so it sees the final self.d_model. Kept isolated from
+        # _compile_weights to avoid touching the existing 200+ line
+        # head/dispatch compilation -- extend, don't refactor.
+        if specialized is not None:
+            self.specialization_ffn = SpecializationFFN(specialized, self.d_model)
+        else:
+            self.specialization_ffn = None
 
     def _compile_weights(self):
         """Set all weight matrices analytically."""
@@ -731,10 +822,18 @@ class CompiledModel(nn.Module):
         if call_embs is None:
             call_embs = torch.zeros(0, self.d_model, dtype=DTYPE)
 
-        # Head 0: Fetch opcode
-        opcode_val, _, _ = self.head_prog_op(query_emb, prog_embs)
-        # Head 1: Fetch argument
-        arg_val, _, _ = self.head_prog_arg(query_emb, prog_embs)
+        if self.specialized is not None:
+            # Specialized mode: fetched opcode/arg come out of the
+            # 2N step-function FFN, not from attention over prog_embs.
+            # prog_embs may be None or empty here.
+            op_scalar, arg_scalar = self.specialization_ffn(query_emb)
+            opcode_val = op_scalar.unsqueeze(0)
+            arg_val = arg_scalar.unsqueeze(0)
+        else:
+            # Head 0: Fetch opcode
+            opcode_val, _, _ = self.head_prog_op(query_emb, prog_embs)
+            # Head 1: Fetch argument
+            arg_val, _, _ = self.head_prog_arg(query_emb, prog_embs)
 
         # Head 2: Read stack[SP]
         if stack_embs.shape[0] > 0:
@@ -823,8 +922,13 @@ class CompiledModel(nn.Module):
         # scalar back. The & MASK32 step lives here, outside the form,
         # for i32-wrap parity with NumPyExecutor — the form itself
         # computes over Z (see ff_symbolic.range_check / equivalence proof).
-        ea = ff_symbolic.E(va, self.d_model)
-        eb = ff_symbolic.E(vb, self.d_model)
+        # ff_symbolic's M_ADD/M_SUB/B_MUL are sized at D_MODEL=51 at module
+        # load (see ff_symbolic._M_ADD_matrix). The scalar va/vb path here
+        # is independent of the residual width, so always lift through the
+        # base D_MODEL embedding regardless of self.d_model (which can be
+        # D_MODEL+2 in specialized mode).
+        ea = ff_symbolic.E(va, D_MODEL)
+        eb = ff_symbolic.E(vb, D_MODEL)
         nonlinear[OPCODE_IDX[OP_ADD]] = float(ff_symbolic.E_inv(
             ff_symbolic.forward_add(ea, eb)) & MASK32)
         nonlinear[OPCODE_IDX[OP_SUB]] = float(ff_symbolic.E_inv(
@@ -946,13 +1050,40 @@ class TorchExecutor:
         self.model = model or CompiledModel()
         self.model.eval()
 
-    def execute(self, prog, max_steps=50000):
-        trace = Trace(program=prog)
+    def execute(self, prog=None, max_steps=50000):
+        # Specialized mode: prog can be None, in which case the trace's
+        # display program is reconstructed from sp.originals.
+        is_specialized = self.model.specialized is not None
+        if is_specialized:
+            spec = self.model.specialized
+            if prog is None:
+                prog = list(spec.originals)
+            n_prog = spec.n
+            prog_embs = None
+        else:
+            n_prog = len(prog)
+            prog_embs = torch.stack([
+                embed_program_token(i, instr)
+                for i, instr in enumerate(prog)
+            ])
 
-        prog_embs = torch.stack([
-            embed_program_token(i, instr)
-            for i, instr in enumerate(prog)
-        ])
+        trace = Trace(program=prog)
+        d_model = self.model.d_model
+
+        def _pad(emb):
+            """Pad a D_MODEL-shaped (1-D or 2-D) tensor to the model's d_model.
+
+            Memory entries are produced by embed_*_entry helpers in the
+            base D_MODEL=51 layout. When the model is specialized, the
+            attention heads expect d_model=53 inputs; the extra dims
+            (DIM_FETCHED_OP / DIM_FETCHED_ARG) are unused for keys/values
+            and so safe to fill with zeros.
+            """
+            if emb.shape[-1] == d_model:
+                return emb
+            pad_shape = list(emb.shape)
+            pad_shape[-1] = d_model - emb.shape[-1]
+            return torch.cat([emb, torch.zeros(*pad_shape, dtype=emb.dtype)], dim=-1)
 
         stack_embs_list = []
         local_embs_list = []
@@ -969,22 +1100,22 @@ class TorchExecutor:
 
         with torch.no_grad():
             for step in range(max_steps):
-                if ip >= len(prog):
+                if ip >= n_prog:
                     break
 
-                query = embed_state(ip, sp)
-                stack_embs = (torch.stack(stack_embs_list)
+                query = _pad(embed_state(ip, sp))
+                stack_embs = (_pad(torch.stack(stack_embs_list))
                               if stack_embs_list
-                              else torch.zeros(0, D_MODEL, dtype=DTYPE))
-                local_embs = (torch.stack(local_embs_list)
+                              else torch.zeros(0, d_model, dtype=DTYPE))
+                local_embs = (_pad(torch.stack(local_embs_list))
                               if local_embs_list
-                              else torch.zeros(0, D_MODEL, dtype=DTYPE))
-                heap_embs = (torch.stack(heap_embs_list)
+                              else torch.zeros(0, d_model, dtype=DTYPE))
+                heap_embs = (_pad(torch.stack(heap_embs_list))
                              if heap_embs_list
-                             else torch.zeros(0, D_MODEL, dtype=DTYPE))
-                call_embs = (torch.stack(call_embs_list)
+                             else torch.zeros(0, d_model, dtype=DTYPE))
+                call_embs = (_pad(torch.stack(call_embs_list))
                              if call_embs_list
-                             else torch.zeros(0, D_MODEL, dtype=DTYPE))
+                             else torch.zeros(0, d_model, dtype=DTYPE))
 
                 opcode, arg, sp_delta, top, _, val_a, val_b, val_c, local_val, heap_val = \
                     self.model.forward(query, prog_embs, stack_embs, local_embs, heap_embs,

--- a/specialize.py
+++ b/specialize.py
@@ -151,3 +151,23 @@ def verify_fetch_parity(prog: List[Instruction]) -> bool:
                 f"specialized={sp.fetch(i)} direct={direct(i)}"
             )
     return True
+
+
+def build_specialized_model(prog, base=None):
+    """Materialize ``prog`` as a specialized ``CompiledModel``.
+
+    Convenience wrapper: specialize the program, then construct a
+    ``CompiledModel(specialized=sp)`` whose FFN holds the 2N step-function
+    neurons. The result has no dependency on a program prefix at runtime --
+    its ``forward`` reads opcode/arg out of two new residual dims.
+
+    Imported lazily so ``specialize`` can be used without pulling torch.
+    """
+    # Unpack (prog, expected) tuples returned by programs.make_*
+    if isinstance(prog, tuple) and len(prog) == 2 and isinstance(prog[0], list):
+        prog = prog[0]
+
+    from executor import CompiledModel  # local import: avoid torch dep at module load
+
+    sp = specialize(prog)
+    return CompiledModel(specialized=sp)

--- a/test_specialize.py
+++ b/test_specialize.py
@@ -24,7 +24,11 @@ from typing import List, Tuple
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from isa import Instruction
+from isa import (
+    Instruction,
+    OP_EQ, OP_LT_S,
+    OP_AND, OP_OR, OP_XOR, OP_SHL,
+)
 from executor import NumPyExecutor
 from programs import (
     ALL_TESTS,
@@ -36,6 +40,7 @@ from programs import (
 )
 from specialize import (
     SpecializedProgram, specialize, verify_fetch_parity, fetch_fn_from_program,
+    build_specialized_model,
 )
 
 
@@ -131,6 +136,73 @@ def _check(name: str, prog_or_test) -> None:
     )
 
 
+# ─── Torch parity: specialized CompiledModel matches universal ──────
+
+def _torch_parity(name: str, prog: List[Instruction], max_steps: int = 50000) -> int:
+    """Run the universal TorchExecutor against a specialized one and
+    assert step-by-step trace equality at TraceStep granularity.
+
+    Specialized executor:
+      - has no program prefix (prog_embs=None inside CompiledModel.forward)
+      - reads (op, arg) at each step from the 2N step-function FFN
+        whose output lives in residual dims DIM_FETCHED_OP /
+        DIM_FETCHED_ARG.
+
+    Acceptance for issue #115. Bit-exact trace parity is the strongest
+    available signal that the analytically constructed weights replay
+    the program correctly.
+    """
+    # Lazy: torch import only when this section runs.
+    from executor import TorchExecutor, CompiledModel, D_MODEL, D_MODEL_SPECIALIZED
+
+    universal_model = CompiledModel()
+    universal = TorchExecutor(universal_model).execute(prog, max_steps=max_steps)
+
+    spec_model = build_specialized_model(prog)
+
+    # Acceptance: shape sanity in the constructor.
+    assert spec_model.d_model == D_MODEL_SPECIALIZED == D_MODEL + 2, (
+        f"{name}: specialized d_model = {spec_model.d_model}, expected {D_MODEL + 2}"
+    )
+    assert spec_model.d_ffn == 2 * len(prog), (
+        f"{name}: specialized d_ffn = {spec_model.d_ffn}, expected {2 * len(prog)}"
+    )
+    assert spec_model.specialization_ffn is not None
+    # The base (non-specialized) model has no FFN.
+    assert universal_model.specialization_ffn is None
+    assert universal_model.d_model == D_MODEL
+    assert universal_model.d_ffn == 0
+
+    # prog_embs=None should be tolerated by the model in specialized mode.
+    specialized = TorchExecutor(spec_model).execute(prog, max_steps=max_steps)
+
+    # Also run with prog=None to confirm the executor can recover the
+    # display program from sp.originals.
+    specialized_no_prog = TorchExecutor(spec_model).execute(None, max_steps=max_steps)
+
+    u = _trace_tuples(universal)
+    s = _trace_tuples(specialized)
+    s2 = _trace_tuples(specialized_no_prog)
+    assert len(u) == len(s) == len(s2), (
+        f"{name}: step counts: universal={len(u)} specialized={len(s)} "
+        f"specialized(no prog)={len(s2)}"
+    )
+    for i, (a, b) in enumerate(zip(u, s)):
+        assert a == b, f"{name}: trace divergence at step {i}: universal={a} specialized={b}"
+    for i, (a, b) in enumerate(zip(u, s2)):
+        assert a == b, (
+            f"{name}: trace divergence (no-prog mode) at step {i}: "
+            f"universal={a} specialized={b}"
+        )
+    return len(u)
+
+
+def _torch_check(name: str, prog_or_test) -> None:
+    prog = _unpack(prog_or_test() if callable(prog_or_test) else prog_or_test)
+    steps = _torch_parity(name, prog)
+    print(f"  {name:34s}  N={len(prog):3d}  steps={steps:5d}  torch-parity OK")
+
+
 def main() -> int:
     print("=" * 72)
     print("Specialization parity: static fetch + execution equivalence (42-op ISA)")
@@ -153,11 +225,22 @@ def main() -> int:
     _check("gcd(48, 18)",         make_gcd(48, 18))
     _check("is_even(14)",         make_is_even(14))
     _check("log2_floor(1024)",    make_log2_floor(1024))
-    _check("compare_binary eq",   make_compare_binary("eq", 3, 3))
-    _check("compare_binary lt_s", make_compare_binary("lt_s", -1, 1))
-    _check("bitwise_binary xor",  make_bitwise_binary("xor", 0xF0F0, 0x0FF0))
-    _check("bitwise_binary shl",  make_bitwise_binary("shl", 1, 5))
+    _check("compare_binary eq",   make_compare_binary(OP_EQ, 3, 3))
+    _check("compare_binary lt_s", make_compare_binary(OP_LT_S, -1, 1))
+    _check("bitwise_binary xor",  make_bitwise_binary(OP_XOR, 0xF0F0, 0x0FF0))
+    _check("bitwise_binary shl",  make_bitwise_binary(OP_SHL, 1, 5))
     _check("select_max(5, 9)",    make_select_max(5, 9))
+
+    print("\n── torch_parity (issue #115: specialized CompiledModel) ──")
+    # Issue #115 acceptance set: countdown(5/20), fibonacci(10),
+    # factorial(5), sum_1_to_n(10), plus the Phase 4 baseline.
+    _torch_check("countdown(5)",       make_countdown(5))
+    _torch_check("countdown(20)",      make_countdown(20))
+    _torch_check("fibonacci(10)",      make_fibonacci(10))
+    _torch_check("factorial(5)",       make_factorial(5))
+    _torch_check("sum_1_to_n(10)",     make_sum_1_to_n(10))
+    for tname, tfn in ALL_TESTS:
+        _torch_check(f"all_tests/{tname}", tfn)
 
     print("\n" + "=" * 72)
     print("OK — all specialization parity tests passed.")


### PR DESCRIPTION
## Summary
- Adds `SpecializationFFN` to `executor.py`: 2N ReLU half-neurons whose pairwise difference `A_i - B_i = 𝟙[ip ≥ i]` for integer ip, with `W_down` accumulating `Σᵢ coef_f[i]·indicatorᵢ` directly into two new residual dims (`DIM_FETCHED_OP`, `DIM_FETCHED_ARG`). Coefficients are read straight from `sp.coefficients['op']` / `sp.coefficients['arg']`.
- Extends `CompiledModel(specialized=sp)`: `d_model` grows by exactly 2 (51→53), `d_ffn` = 2N, and `forward` reads opcode/arg from the FFN instead of `head_prog_op` / `head_prog_arg`. `prog_embs` becomes optional.
- `TorchExecutor.execute` skips program-embedding construction when specialized; `prog` may be `None` (display recovered from `sp.originals`); memory entries are zero-padded to the wider `d_model`.
- New `specialize.build_specialized_model(prog)` ergonomic helper.
- `test_specialize.py` gains a `torch_parity` section asserting bit-exact `TraceStep` parity between universal and specialized `TorchExecutor` over the issue #115 acceptance set: `countdown(5)`, `countdown(20)`, `fibonacci(10)`, `factorial(5)`, `sum_1_to_n(10)`, plus the Phase 4 `ALL_TESTS` baseline. All 15 programs pass.

## Acceptance
- [x] `CompiledModel(specialized=sp)` exists and type-checks
- [x] `d_ffn` grows by exactly `2N`, `d_model` grows by exactly 2; verified in the constructor
- [x] Weight shape sanity: `countdown(5)` (n=6) gains 672 FFN params = 2N·d_model + 2N (bias) + 2·2N = 12·53 + 12 + 24 — exact match
- [x] `TorchExecutor` runs specialized model with `prog_embs=None` (also accepts `prog=None`)
- [x] Trace parity on countdown(5), countdown(20), fibonacci(10), factorial(5), sum_1_to_n(10) at TraceStep granularity
- [x] Trace parity across `ALL_TESTS` (Phase 4 baseline, 10 programs)
- [x] `test_specialize.py::torch_parity` added and passes

## Implementation notes
- The indicator construction uses two ReLU "half-neurons" per instruction (gate + up) whose linear combination — not product — gives the integer indicator. The issue's "ReGLU product" framing assumed clipping; in practice `ReLU(ip-i+1) - ReLU(ip-i)` is bit-exact for any integer ip ≥ 0 and avoids a clipping nonlinearity, while still costing 2N hidden neurons as specified. `SpecializationFFN.__doc__` makes this explicit.
- `ff_symbolic.M_ADD` etc. are sized at `D_MODEL=51` at module load. The `forward()` path that lifts `(va, vb)` through `ff_symbolic.E` now passes `D_MODEL` explicitly instead of `self.d_model`, so the bilinear forms keep working when the residual is widened by specialization.
- Drive-by fix in `test_specialize.py`: four calls to `make_compare_binary`/`make_bitwise_binary` were passing string opcodes (`"eq"`, `"lt_s"`, `"xor"`, `"shl"`) when those functions expect integer opcode constants — pre-existing failure on `main` independent of this PR.

## Out of scope
- `executor.mojo` — uses direct list indexing already (no specialization speedup), unchanged per the issue.
- The existing `test_consolidated.py` is broken on `main` (`ModuleNotFoundError: phase14_extended_isa`); not regressed here.

## Test plan
- [x] `python3 test_specialize.py` — full pass, 15 torch_parity programs trace-equal to universal
- [x] `python3 test_ff_symbolic.py` — passes (no regression in the bilinear-FF surface)
- [x] Constructor invariants: `base.d_model=51`, `base.d_ffn=0`, `base.specialization_ffn is None`; `spec.d_model=53`, `spec.d_ffn=2N`, `spec.specialization_ffn is not None`

Closes #115.