### PR TITLE
fix: restore test_consolidated.py imports after phase14 move

### DIFF
--- a/test_consolidated.py
+++ b/test_consolidated.py
@@ -8,7 +8,9 @@ import sys
 import os
 import time
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _HERE)
+sys.path.insert(0, os.path.join(_HERE, "dev", "phases"))
 
 from isa import (
     Instruction, compare_traces, _test_algorithm, _test_trap_algorithm,


### PR DESCRIPTION
## Summary
- `phase14_extended_isa.py` was moved to `dev/phases/` in 006c330, but `test_consolidated.py` still imported it as a top-level module — `python3 test_consolidated.py` died with `ModuleNotFoundError: phase14_extended_isa` on `main`.
- Fix: add `dev/phases/` to `sys.path` alongside the repo root so the legacy `Phase14Executor` / `Phase14PyTorchExecutor` used as the cross-validation oracle remain importable.

## Context
Noted as a pre-existing failure in #116 ("The existing test_consolidated.py is broken on main… not regressed here"). This PR restores it.

## Test plan
- [x] `python3 test_consolidated.py` — all three sections pass
  - NumPy equivalence: 50/50
  - Torch equivalence: 33/33
  - Internal consistency (new np vs new pt): 39/39
- [x] Total: 122/122 in 1.05s

https://claude.ai/code/session_01LTYparKQQAcG6DigKygB81