### PR TITLE
Paged (two-level) float32 addressing — fix for #120 capacity law

### DIFF
--- a/paged_addressing.py
+++ b/paged_addressing.py
@@ -1,0 +1,132 @@
+"""Paged (two-level) parabolic addressing — fix for the float32 capacity law.
+
+Issue #120 establishes the closed-form addressing capacity law for flat
+parabolic keys k_j = (2j, -j²) with query (j, 1):
+
+    exact retrieval holds iff j² ≤ 2^(significand bits)
+
+The winning score has magnitude j² and beats the runner-up by exactly 1;
+float32 (24-bit significand) has ULP 2 for values in [2²⁴, 2²⁵), so every
+index j > 4096 misaddresses. The break is a step function at N = 4096,
+not the "~4–7K" blur the March benchmarks reported (that was pipeline
+noise on top of this law).
+
+This module implements proposed fix 2: two-level paged addressing. An
+address a splits into (page, offset) = (a // P, a % P) with P ≤ 4096.
+Level 1 is one hard-attention call over a page directory (parabolic keys
+on page ids); level 2 is one hard-attention call over the entries of the
+selected page (parabolic keys on offsets). Each level's score magnitude
+stays ≤ P² ≤ 2²⁴, under the float32 ULP wall, so retrieval remains EXACT
+— capacity P² ≈ 16.7M addresses in pure float32 for one extra head.
+
+Rate–distortion reading: exact addressing is the zero-distortion endpoint
+of the quantizer frontier, so capacity is the rate budget of the score
+dtype; paging splits that rate budget across levels. L levels give P^L.
+
+Both levels below are literal attention math — float32 key matrix, dot
+product with the query, argmax — matching the semantics of
+CompiledAttentionHead / NumPyExecutor.heap_read. The page-directory dict
+is storage layout only, the same role the executor's Python lists play.
+
+Fix 1 (fp64 score accumulation, capacity ~9×10⁷) is de facto the repo's
+status quo: isa.DTYPE is torch.float64 and NumPyExecutor builds float64
+arrays. This module is the fix that keeps float32 viable.
+"""
+
+import numpy as np
+from typing import Optional
+
+DEFAULT_PAGE_SIZE = 4096  # exactly the float32 capacity boundary from #120
+
+# NOTE on recency: NumPyExecutor breaks overwrite ties with an
+# EPS·write_count key bias, which works because its keys are float64.
+# In float32 that bias is INERT — within-page scores are integers of
+# magnitude up to ~2²⁴, where the ULP is 1, so any sub-1 bias rounds
+# away and duplicate writes produce exactly tied keys. This module
+# breaks ties positionally instead (argmax-to-latest), the float32-
+# faithful equivalent of the same convention.
+
+
+def flat_misaddressed(dtype, n: int) -> int:
+    """Count misaddressed indices for flat parabolic addressing at size n.
+
+    Reference measurement from issue #120. For float32 the law predicts
+    max(0, n - 4097): every index above 4096 fails, every index at or
+    below stays exact.
+    """
+    j = np.arange(n, dtype=dtype)
+    keys = np.stack([2 * j, -(j * j)], axis=1).astype(dtype)
+    bad = 0
+    for q in range(n):
+        scores = dtype(q) * keys[:, 0] + keys[:, 1]
+        if int(np.argmax(scores)) != q:
+            bad += 1
+    return bad
+
+
+class PagedAttentionMemory:
+    """Two-level parabolic addressing memory, exact in float32 up to P².
+
+    write(addr, val) / read(addr) semantics match the executor's heap:
+    reads of untouched addresses return 0; overwrites resolve to the most
+    recent write via the same EPS·write_count recency bias the flat
+    scheme uses.
+    """
+
+    def __init__(self, page_size: int = DEFAULT_PAGE_SIZE, dtype=np.float32):
+        if page_size > 4096 and dtype == np.float32:
+            raise ValueError(
+                f"page_size {page_size} > 4096 exceeds the float32 "
+                f"capacity law (j² ≤ 2²⁴) from issue #120"
+            )
+        self.P = page_size
+        self.dtype = dtype
+        # Page directory: page_id -> (offset_keys, values). Storage layout
+        # only; all retrieval math below is float32 attention.
+        self._pages = {}
+        self._dir_keys = []   # parabolic keys over page ids, one per page
+        self._dir_ids = []    # page id per directory row
+
+    def max_addressable(self) -> int:
+        return self.P * self.P
+
+    def _split(self, addr: int):
+        return addr // self.P, addr % self.P
+
+    def write(self, addr: int, val):
+        page, off = self._split(addr)
+        if page >= self.P:
+            raise ValueError(f"addr {addr} exceeds capacity {self.P * self.P}")
+        if page not in self._pages:
+            self._pages[page] = ([], [])
+            self._dir_keys.append(
+                (self.dtype(2 * page), self.dtype(-(page * page)))
+            )
+            self._dir_ids.append(page)
+        keys, vals = self._pages[page]
+        keys.append((self.dtype(2 * off), self.dtype(-(off * off))))
+        vals.append(val)
+
+    def read(self, addr: int):
+        """Two hard-attention calls: page select, then offset select."""
+        if not self._dir_keys:
+            return 0
+        page, off = self._split(addr)
+
+        # Level 1: attention over the page directory.
+        dir_keys = np.array(self._dir_keys, dtype=self.dtype)
+        q1 = np.array([page, 1.0], dtype=self.dtype)
+        best_dir = int(np.argmax(dir_keys @ q1))
+        selected = self._dir_ids[best_dir]
+        if selected != page:
+            return 0  # page not present; parabola peaked elsewhere
+
+        # Level 2: attention over the selected page's entries.
+        keys, vals = self._pages[selected]
+        page_keys = np.array(keys, dtype=self.dtype)
+        q2 = np.array([off, 1.0], dtype=self.dtype)
+        scores = page_keys @ q2
+        # argmax with tie-break to the LATEST write (see recency NOTE above)
+        best = len(scores) - 1 - int(np.argmax(scores[::-1]))
+        stored_off = round(float(page_keys[best, 0]) / 2.0)
+        return vals[best] if stored_off == off else 0

--- a/test_paged_addressing.py
+++ b/test_paged_addressing.py
@@ -1,0 +1,113 @@
+"""Tests for the #120 addressing capacity law and paged addressing fix.
+
+The law: flat parabolic addressing in float32 is exact iff j ≤ 4096 —
+misaddressed count at size N is exactly max(0, N - 4097), a step
+function. Paged addressing keeps every level under the wall and stays
+exact in float32 across the full P² address space.
+"""
+
+import sys
+import random
+
+import numpy as np
+
+from paged_addressing import (
+    PagedAttentionMemory, flat_misaddressed, DEFAULT_PAGE_SIZE,
+)
+
+
+# ─── The capacity law itself (regression-pins issue #120) ─────────
+
+def test_flat_float32_exact_at_4096():
+    assert flat_misaddressed(np.float32, 4096) == 0
+
+
+def test_flat_float32_cliff_is_step_function():
+    # every index above 4096 misaddresses: count == N - 4097
+    for n in (4608, 5120, 6144):
+        assert flat_misaddressed(np.float32, n) == n - 4097, n
+
+
+def test_flat_float64_exact_at_65536():
+    assert flat_misaddressed(np.float64, 65536) == 0
+
+
+# ─── Paged addressing: exact float32 retrieval beyond the wall ────
+
+def test_paged_exact_across_full_range():
+    m = PagedAttentionMemory()  # P=4096, float32, capacity 16.7M
+    rng = random.Random(120)
+    hi = m.max_addressable()
+    addrs = ([0, 1, 4095, 4096, 4097, 8191, 8192, hi - 1]
+             + [rng.randrange(hi) for _ in range(500)])
+    written = {}
+    for a in addrs:
+        v = rng.randrange(1, 10**6)
+        m.write(a, v)
+        written[a] = v
+    for a, v in written.items():
+        assert m.read(a) == v, f"addr {a}"
+
+
+def test_paged_exact_where_flat_float32_fails():
+    # indices 4097..8192 all misaddress under flat float32 (the law);
+    # under paging every one reads back exactly.
+    m = PagedAttentionMemory()
+    for a in range(4097, 8193, 41):
+        m.write(a, a * 3 + 1)
+    for a in range(4097, 8193, 41):
+        assert m.read(a) == a * 3 + 1, f"addr {a}"
+
+
+def test_untouched_address_reads_zero():
+    m = PagedAttentionMemory()
+    m.write(5000, 7)
+    assert m.read(5001) == 0        # same page, absent offset
+    assert m.read(9_000_000) == 0   # absent page
+
+
+def test_overwrite_resolves_to_latest():
+    m = PagedAttentionMemory()
+    m.write(123456, 1)
+    m.write(123456, 2)
+    assert m.read(123456) == 2
+
+
+def test_page_size_over_wall_rejected():
+    try:
+        PagedAttentionMemory(page_size=5000)
+    except ValueError:
+        return
+    raise AssertionError("page_size > 4096 in float32 must be rejected")
+
+
+def test_capacity():
+    assert PagedAttentionMemory().max_addressable() == DEFAULT_PAGE_SIZE ** 2
+
+
+def main():
+    tests = [
+        test_flat_float32_exact_at_4096,
+        test_flat_float32_cliff_is_step_function,
+        test_flat_float64_exact_at_65536,
+        test_paged_exact_across_full_range,
+        test_paged_exact_where_flat_float32_fails,
+        test_untouched_address_reads_zero,
+        test_overwrite_resolves_to_latest,
+        test_page_size_over_wall_rejected,
+        test_capacity,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  ✓ {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  ✗ {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} tests passed")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
*Filed by Muninn*

Implements fix 2 from #120: two-level paged parabolic addressing, exact in pure float32 across P² ≈ 16.7M addresses (P=4096, the capacity boundary). Each level is one hard-attention call — float32 key matrix, dot product, argmax — matching CompiledAttentionHead / NumPyExecutor.heap_read semantics; the page directory dict is storage layout only.

Fix 1 (fp64 score accumulation) is noted as de facto status quo: isa.DTYPE is torch.float64 and NumPyExecutor builds float64 arrays. This PR is what keeps float32 viable.

Also regression-pins the capacity law itself: tests assert flat float32 misaddressing is exactly max(0, N−4097) at N ∈ {4096, 4608, 5120, 6144} and float64 is exact at 65536.

One finding surfaced during implementation: the executor's EPS·write_count overwrite-recency bias is inert in float32 — within-page scores are integers up to ~2²⁴ where ULP is 1, so a 1e-10 bias rounds away and duplicate keys tie exactly. The paged module breaks ties positionally (argmax-to-latest) instead; documented in the module NOTE.

Verified in-session: `python3 test_paged_addressing.py` — 9/9 pass (numpy-only by design). NOT verified in-session (torch absent in container): the existing suite — run `python3 test_consolidated.py && python3 test_closed_form.py` first. Regression risk is nominal (two new files, no existing file touched).

Closes #120.